### PR TITLE
JBPM-8320: Redesign of ProcessRuntime API

### DIFF
--- a/api/kie-api/src/main/java/org/kie/api/runtime/process/ProcessInstance.java
+++ b/api/kie-api/src/main/java/org/kie/api/runtime/process/ProcessInstance.java
@@ -16,6 +16,8 @@
 
 package org.kie.api.runtime.process;
 
+import java.util.Map;
+
 import org.kie.api.definition.process.Process;
 
 /**
@@ -86,5 +88,11 @@ public interface ProcessInstance
      * @return the unique id of parent process instance, 0 if this process instance doesn't have a parent
      */
     long getParentProcessInstanceId();
+    
+    /**
+     * Returns current snapshot of process instance variables
+     * @return non empty map of process instance variables
+     */
+    Map<String, Object> getVariables();
 
 }

--- a/api/kie-api/src/main/java/org/kie/submarine/Config.java
+++ b/api/kie-api/src/main/java/org/kie/submarine/Config.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine;
+
+import org.kie.submarine.process.ProcessConfig;
+
+public interface Config {
+    ProcessConfig process();
+}

--- a/api/kie-api/src/main/java/org/kie/submarine/StaticConfig.java
+++ b/api/kie-api/src/main/java/org/kie/submarine/StaticConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine;
+
+import org.kie.submarine.process.ProcessConfig;
+
+public class StaticConfig implements Config {
+
+    private final ProcessConfig processConfig;
+
+    public StaticConfig(ProcessConfig processConfig) {
+        this.processConfig = processConfig;
+    }
+
+    @Override
+    public ProcessConfig process() {
+        return this.processConfig;
+    }
+}

--- a/api/kie-api/src/main/java/org/kie/submarine/process/Process.java
+++ b/api/kie-api/src/main/java/org/kie/submarine/process/Process.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine.process;
+
+public interface Process<T> {
+
+    ProcessInstance<T> createInstance(T workingMemory);
+
+    ProcessInstances<T> instances();
+
+    <S> void send(Signal<S> sig);
+}

--- a/api/kie-api/src/main/java/org/kie/submarine/process/ProcessConfig.java
+++ b/api/kie-api/src/main/java/org/kie/submarine/process/ProcessConfig.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine.process;
+
+public interface ProcessConfig {
+    WorkItemHandlerConfig workItemHandlers();
+}

--- a/api/kie-api/src/main/java/org/kie/submarine/process/ProcessInstance.java
+++ b/api/kie-api/src/main/java/org/kie/submarine/process/ProcessInstance.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine.process;
+
+public interface ProcessInstance<T> {
+    Process<T> process();
+    void start();
+    <S> void send(Signal<S> signal);
+    void abort();
+    T variables();
+}

--- a/api/kie-api/src/main/java/org/kie/submarine/process/ProcessInstances.java
+++ b/api/kie-api/src/main/java/org/kie/submarine/process/ProcessInstances.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine.process;
+
+import java.util.Collection;
+import java.util.Optional;
+
+public interface ProcessInstances<T> {
+
+    Optional<? extends ProcessInstance<T>> findById(long i);
+
+    Collection<? extends ProcessInstance<T>> values();
+}

--- a/api/kie-api/src/main/java/org/kie/submarine/process/Signal.java
+++ b/api/kie-api/src/main/java/org/kie/submarine/process/Signal.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine.process;
+
+public interface Signal<T> {
+
+    String channel();
+
+    T payload();
+}

--- a/api/kie-api/src/main/java/org/kie/submarine/process/WorkItemHandlerConfig.java
+++ b/api/kie-api/src/main/java/org/kie/submarine/process/WorkItemHandlerConfig.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine.process;
+
+import java.util.Collection;
+
+import org.kie.api.runtime.process.WorkItemHandler;
+
+public interface WorkItemHandlerConfig {
+
+    WorkItemHandler forName(String name);
+
+    Collection<String> names();
+}

--- a/api/kie-api/src/main/java/org/kie/submarine/rules/DataSource.java
+++ b/api/kie-api/src/main/java/org/kie/submarine/rules/DataSource.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.submarine.rules;
 
 import org.kie.api.runtime.rule.FactHandle;

--- a/api/kie-api/src/main/java/org/kie/submarine/rules/RuleUnit.java
+++ b/api/kie-api/src/main/java/org/kie/submarine/rules/RuleUnit.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.submarine.rules;
 
 public interface RuleUnit<T> {

--- a/api/kie-api/src/main/java/org/kie/submarine/rules/RuleUnitInstance.java
+++ b/api/kie-api/src/main/java/org/kie/submarine/rules/RuleUnitInstance.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.submarine.rules;
 
 public interface RuleUnitInstance<T> {

--- a/api/kie-api/src/main/java/org/kie/submarine/rules/Unit.java
+++ b/api/kie-api/src/main/java/org/kie/submarine/rules/Unit.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.submarine.rules;
 
 public @interface Unit {

--- a/api/kie-api/src/main/java/org/kie/submarine/rules/impl/AbstractRuleUnit.java
+++ b/api/kie-api/src/main/java/org/kie/submarine/rules/impl/AbstractRuleUnit.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.submarine.rules.impl;
 
 import org.kie.submarine.rules.RuleUnit;

--- a/api/kie-api/src/main/java/org/kie/submarine/rules/impl/AbstractRuleUnitInstance.java
+++ b/api/kie-api/src/main/java/org/kie/submarine/rules/impl/AbstractRuleUnitInstance.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.submarine.rules.impl;
 
 import java.lang.reflect.Field;

--- a/api/kie-api/src/main/java/org/kie/submarine/rules/impl/ListDataSource.java
+++ b/api/kie-api/src/main/java/org/kie/submarine/rules/impl/ListDataSource.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.submarine.rules.impl;
 
 import java.util.ArrayList;

--- a/api/kie-services/src/main/java/org/kie/services/signal/LightSignalManager.java
+++ b/api/kie-services/src/main/java/org/kie/services/signal/LightSignalManager.java
@@ -18,6 +18,8 @@ package org.kie.services.signal;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.kie.api.runtime.process.EventListener;
@@ -25,7 +27,7 @@ import org.kie.api.runtime.process.EventListener;
 public class LightSignalManager implements SignalManager {
 
 	private final EventListenerResolver instanceResolver;
-	private ConcurrentHashMap<String, ArrayList<EventListener>> listeners =
+	private ConcurrentHashMap<String, List<EventListener>> listeners =
 			new ConcurrentHashMap<>();
 
 	public LightSignalManager(EventListenerResolver instanceResolver) {
@@ -50,8 +52,7 @@ public class LightSignalManager implements SignalManager {
 	}
 	
 	public void signalEvent(String type, Object event) {
-		listeners.values().stream()
-				.flatMap(Collection::stream)
+		listeners.getOrDefault(type, Collections.emptyList())
 				.forEach(e -> e.signalEvent(type, event));
 	}
 

--- a/archetypes/kaas-springboot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/kaas-springboot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -21,6 +21,7 @@
     <submarine.version>8.0.0-SNAPSHOT</submarine.version>
     <swagger.version>1.5.21</swagger.version>
     <cxf.version>3.2.6</cxf.version>
+    <dependencyInjection>false</dependencyInjection>
   </properties>
 
   <dependencies>

--- a/drools/drools-compiler/src/test/java/org/drools/compiler/integrationtests/WorkingMemoryLoggerTest.java
+++ b/drools/drools-compiler/src/test/java/org/drools/compiler/integrationtests/WorkingMemoryLoggerTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.fail;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.drools.compiler.Cheese;
 import org.drools.compiler.CommonTestMethodBase;
@@ -278,6 +279,11 @@ public class WorkingMemoryLoggerTest extends CommonTestMethodBase {
 
         @Override
         public void setVariable(String name, Object value) {
+        }
+
+        @Override
+        public Map<String, Object> getVariables() {
+            return null;
         }
 
     }

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleUnitSourceClass.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleUnitSourceClass.java
@@ -27,7 +27,7 @@ public class RuleUnitSourceClass {
     private final String canonicalName;
     private final String targetCanonicalName;
     private String targetTypeName;
-    private boolean hasCdi = false;
+    private boolean hasCdi;
 
     public RuleUnitSourceClass(String packageName, String typeName, String generatedSourceFile) {
         this.packageName = packageName;
@@ -78,8 +78,7 @@ public class RuleUnitSourceClass {
                 .addParameter(canonicalName, "value")
                 .setType(ruleUnitInstanceFQCN)
                 .setBody(new BlockStmt()
-                                 .addStatement(returnStmt)
-                );
+                                 .addStatement(returnStmt));
         return methodDeclaration;
     }
 
@@ -121,9 +120,7 @@ public class RuleUnitSourceClass {
         ClassOrInterfaceDeclaration cls = new ClassOrInterfaceDeclaration()
                 .setName(targetTypeName)
                 .setModifiers(Modifier.Keyword.PUBLIC);
-        if (hasCdi) {
-            cls.addAnnotation("javax.enterprise.context.ApplicationScoped");
-        }
+        cls.addAnnotation("javax.inject.Singleton");
         String ruleUnitInstanceFQCN = RuleUnitInstanceSourceClass.qualifiedName(packageName, typeName);
 
         MethodDeclaration methodDeclaration = createInstanceMethod(ruleUnitInstanceFQCN);
@@ -133,7 +130,7 @@ public class RuleUnitSourceClass {
     }
 
     public RuleUnitSourceClass withCdi(boolean hasCdi) {
-        this.hasCdi = true;
+        this.hasCdi = hasCdi;
         return this;
     }
 }

--- a/jbpm/jbpm-bpmn2/src/main/java/org/kie/submarine/process/bpmn2/BpmnProcess.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/kie/submarine/process/bpmn2/BpmnProcess.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine.process.bpmn2;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.drools.core.xml.SemanticModules;
+import org.jbpm.bpmn2.xml.BPMNDISemanticModule;
+import org.jbpm.bpmn2.xml.BPMNExtensionsSemanticModule;
+import org.jbpm.bpmn2.xml.BPMNSemanticModule;
+import org.jbpm.compiler.xml.XmlProcessReader;
+import org.jbpm.process.instance.LightProcessRuntimeServiceProvider;
+import org.kie.api.definition.process.Process;
+import org.kie.api.io.Resource;
+import org.kie.submarine.process.ProcessInstance;
+import org.kie.submarine.process.impl.AbstractProcess;
+
+public class BpmnProcess extends AbstractProcess<BpmnVariables> {
+
+    private static final SemanticModules BPMN_SEMANTIC_MODULES = new SemanticModules();
+
+    static {
+        BPMN_SEMANTIC_MODULES.addSemanticModule(new BPMNSemanticModule());
+        BPMN_SEMANTIC_MODULES.addSemanticModule(new BPMNExtensionsSemanticModule());
+        BPMN_SEMANTIC_MODULES.addSemanticModule(new BPMNDISemanticModule());
+    }
+
+    private final Process process;
+
+    public BpmnProcess(Process p) {
+        process = p;
+    }
+
+    public ProcessInstance<BpmnVariables> createInstance() {
+        return new BpmnProcessInstance(this, BpmnVariables.create(), this.createLegacyProcessRuntime());
+    }
+
+    @Override
+    public ProcessInstance<BpmnVariables> createInstance(BpmnVariables variables) {
+        return new BpmnProcessInstance(this, variables, this.createLegacyProcessRuntime());
+    }
+
+    public static List<BpmnProcess> from(Resource resource) {
+        try {
+            XmlProcessReader xmlReader = new XmlProcessReader(
+                    BPMN_SEMANTIC_MODULES,
+                    Thread.currentThread().getContextClassLoader());
+            List<Process> processes = xmlReader.read(resource.getReader());
+            return processes.stream().map(BpmnProcess::new).collect(Collectors.toList());
+        } catch (Exception e) {
+            throw new BpmnProcessReaderException(e);
+        }
+    }
+
+    @Override
+    protected Process legacyProcess() {
+        return process;
+    }
+}

--- a/jbpm/jbpm-bpmn2/src/main/java/org/kie/submarine/process/bpmn2/BpmnProcessInstance.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/kie/submarine/process/bpmn2/BpmnProcessInstance.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine.process.bpmn2;
+
+import java.util.Map;
+
+import org.kie.api.runtime.process.ProcessRuntime;
+import org.kie.submarine.process.impl.AbstractProcess;
+import org.kie.submarine.process.impl.AbstractProcessInstance;
+
+public class BpmnProcessInstance extends AbstractProcessInstance<BpmnVariables> {
+
+    public BpmnProcessInstance(AbstractProcess<BpmnVariables> process, BpmnVariables variables, ProcessRuntime rt) {
+        super(process, variables, rt);
+    }
+
+    @Override
+    protected Map<String, Object> bind(BpmnVariables variables) {
+        return variables.asMap();
+    }
+
+    @Override
+    protected void unbind(BpmnVariables variables, Map<String, Object> vmap) {
+        variables.fromMap(vmap);
+    }
+}

--- a/jbpm/jbpm-bpmn2/src/main/java/org/kie/submarine/process/bpmn2/BpmnProcessReaderException.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/kie/submarine/process/bpmn2/BpmnProcessReaderException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine.process.bpmn2;
+
+public class BpmnProcessReaderException extends RuntimeException {
+
+    public BpmnProcessReaderException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/jbpm/jbpm-bpmn2/src/main/java/org/kie/submarine/process/bpmn2/BpmnVariables.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/kie/submarine/process/bpmn2/BpmnVariables.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine.process.bpmn2;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class BpmnVariables {
+
+    private final Map<String, Object> variables = new HashMap<>();
+
+    private BpmnVariables(){}
+
+    public static BpmnVariables create() {
+        return new BpmnVariables();
+    }
+
+    public Object get(String v) {
+        return variables.get(v);
+    }
+
+    public BpmnVariables set(String v, Object o) {
+        variables.put(v, o);
+        return this;
+    }
+
+    public Map<String, Object> asMap() {
+        return Collections.unmodifiableMap(variables);
+    }
+
+    public void fromMap(Map<String, Object> vs) {
+        variables.putAll(vs);
+    }
+}

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/canonical/ActivityGenerationModelTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/canonical/ActivityGenerationModelTest.java
@@ -75,7 +75,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         KieBase kbase = createKnowledgeBase("BPMN2-MinimalProcess.bpmn2");
                 
         ProcessMetaData metaData = ProcessToExecModelGenerator.INSTANCE.generate((WorkflowProcess) kbase.getProcess("Minimal"));        
-        String content = metaData.getGeneratedClassModel();
+        String content = metaData.getGeneratedClassModel().toString();
         assertThat(content).isNotNull();
         log(content);
         
@@ -92,7 +92,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         KieBase kbase = createKnowledgeBase("BPMN2-UserTask.bpmn2");
                 
         ProcessMetaData metaData = ProcessToExecModelGenerator.INSTANCE.generate((WorkflowProcess) kbase.getProcess("UserTask"));        
-        String content = metaData.getGeneratedClassModel();
+        String content = metaData.getGeneratedClassModel().toString();
         assertThat(content).isNotNull();
         log(content);
         
@@ -117,7 +117,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         KieBase kbase = createKnowledgeBase("BPMN2-UserTaskWithParametrizedInput.bpmn2");
                 
         ProcessMetaData metaData = ProcessToExecModelGenerator.INSTANCE.generate((WorkflowProcess) kbase.getProcess("UserTask"));        
-        String content = metaData.getGeneratedClassModel();
+        String content = metaData.getGeneratedClassModel().toString();
         assertThat(content).isNotNull();
         log(content);
         
@@ -144,7 +144,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         KieBase kbase = createKnowledgeBase("BPMN2-CallActivitySubProcess.bpmn2");
                 
         ProcessMetaData metaData = ProcessToExecModelGenerator.INSTANCE.generate((WorkflowProcess) kbase.getProcess("SubProcess"));        
-        String content = metaData.getGeneratedClassModel();
+        String content = metaData.getGeneratedClassModel().toString();
         assertThat(content).isNotNull();
         log(content);
         
@@ -161,7 +161,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         KieBase kbase = createKnowledgeBase("BPMN2-ExclusiveSplit.bpmn2");
         
         ProcessMetaData metaData = ProcessToExecModelGenerator.INSTANCE.generate((WorkflowProcess) kbase.getProcess("com.sample.test"));        
-        String content = metaData.getGeneratedClassModel();
+        String content = metaData.getGeneratedClassModel().toString();
         assertThat(content).isNotNull();
         log(content);
         
@@ -182,7 +182,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
     public void testInclusiveSplit() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2-InclusiveSplit.bpmn2");
         ProcessMetaData metaData = ProcessToExecModelGenerator.INSTANCE.generate((WorkflowProcess) kbase.getProcess("com.sample.test"));        
-        String content = metaData.getGeneratedClassModel();
+        String content = metaData.getGeneratedClassModel().toString();
         assertThat(content).isNotNull();
         log(content);
         
@@ -202,7 +202,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
     public void testInclusiveSplitDefaultConnection() throws Exception {
         KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-InclusiveGatewayWithDefault.bpmn2");
         ProcessMetaData metaData = ProcessToExecModelGenerator.INSTANCE.generate((WorkflowProcess) kbase.getProcess("InclusiveGatewayWithDefault"));        
-        String content = metaData.getGeneratedClassModel();
+        String content = metaData.getGeneratedClassModel().toString();
         assertThat(content).isNotNull();
         log(content);
         
@@ -221,7 +221,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
     public void testParallelGateway() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2-ParallelSplit.bpmn2");
         ProcessMetaData metaData = ProcessToExecModelGenerator.INSTANCE.generate((WorkflowProcess) kbase.getProcess("com.sample.test"));        
-        String content = metaData.getGeneratedClassModel();
+        String content = metaData.getGeneratedClassModel().toString();
         assertThat(content).isNotNull();
         log(content);
         
@@ -238,7 +238,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
     public void testInclusiveSplitAndJoinNested() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2-InclusiveSplitAndJoinNested.bpmn2");
         ProcessMetaData metaData = ProcessToExecModelGenerator.INSTANCE.generate((WorkflowProcess) kbase.getProcess("com.sample.test"));        
-        String content = metaData.getGeneratedClassModel();
+        String content = metaData.getGeneratedClassModel().toString();
         assertThat(content).isNotNull();
         log(content);
         
@@ -283,7 +283,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         KieBase kbase = createKnowledgeBase("BPMN2-ServiceProcess.bpmn2");
                 
         ProcessMetaData metaData = ProcessToExecModelGenerator.INSTANCE.generate((WorkflowProcess) kbase.getProcess("ServiceProcess"));        
-        String content = metaData.getGeneratedClassModel();
+        String content = metaData.getGeneratedClassModel().toString();
         assertThat(content).isNotNull();
         log(content);
         

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/AbstractVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/AbstractVisitor.java
@@ -102,6 +102,24 @@ public abstract class AbstractVisitor {
         return new ExpressionStmt(assignExpr);
     }
 
+    protected Statement makeVariableAssignment(Variable v) {
+        ClassOrInterfaceType type = JavaParser.parseClassOrInterfaceType(v.getType().getStringType());
+        String name = v.getName();
+
+        // `type` `name` = (`type`) `kcontext.getVariable
+        AssignExpr assignExpr = new AssignExpr(
+                new VariableDeclarationExpr(type, name),
+                new CastExpr(
+                        type,
+                        new MethodCallExpr(
+                                new NameExpr("kcontext"),
+                                "getVariable")
+                                .addArgument(new StringLiteralExpr(name))),
+                AssignExpr.Operator.ASSIGN);
+
+        return new ExpressionStmt(assignExpr);
+    }
+
     protected String getOrDefault(String value, String defaultValue) {
         if (value == null) {
             return defaultValue;
@@ -110,9 +128,14 @@ public abstract class AbstractVisitor {
         return value;
     }
 
+
+
     protected void addWorkItemParameters(Work work, BlockStmt body, String variableName) {
 
         for (Entry<String, Object> entry : work.getParameters().entrySet()) {
+            if (entry.getValue() == null) {
+                continue; // interfaceImplementationRef ?
+            }
             addFactoryMethodWithArgs(body, variableName, "workParameter", new StringLiteralExpr(entry.getKey()), new StringLiteralExpr(entry.getValue().toString()));
         }
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/AbstractVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/AbstractVisitor.java
@@ -19,6 +19,7 @@ package org.jbpm.compiler.canonical;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.drools.core.util.StringUtils;
 import org.jbpm.process.core.ParameterDefinition;
 import org.jbpm.process.core.Work;
 import org.jbpm.process.core.context.variable.Variable;
@@ -97,6 +98,23 @@ public abstract class AbstractVisitor {
                                                                                new NameExpr("kcontext"),
                                                                                "getVariable")
                                                                                              .addArgument(new StringLiteralExpr(name))),
+                                               AssignExpr.Operator.ASSIGN);
+
+        return new ExpressionStmt(assignExpr);
+    }
+    
+    protected Statement makeAssignmentFromModel(Variable v) {
+        ClassOrInterfaceType type = JavaParser.parseClassOrInterfaceType(v.getType().getStringType());
+        String name = v.getName();
+
+        // `type` `name` = (`type`) `kcontext.getVariable
+        AssignExpr assignExpr = new AssignExpr(
+                                               new VariableDeclarationExpr(type, name),
+                                               new CastExpr(
+                                                            type,
+                                                            new MethodCallExpr(
+                                                                               new NameExpr("model"),
+                                                                               "get" + StringUtils.capitalize(name))),
                                                AssignExpr.Operator.ASSIGN);
 
         return new ExpressionStmt(assignExpr);

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/LambdaSubProcessNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/LambdaSubProcessNodeVisitor.java
@@ -105,7 +105,7 @@ public class LambdaSubProcessNodeVisitor extends AbstractVisitor {
         BlockStmt stmts = new BlockStmt();
 
         for (Map.Entry<String, String> e : subProcessNode.getOutMappings().entrySet()) {
-            stmts.addStatement(makeAssignment(variableScope.findVariable(e.getKey())));
+            stmts.addStatement(makeAssignmentFromModel(variableScope.findVariable(e.getKey())));
             stmts.addStatement(new MethodCallExpr()
                                        .setScope(new NameExpr("kcontext"))
                                        .setName("setVariable")

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/LambdaSubProcessNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/LambdaSubProcessNodeVisitor.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.compiler.canonical;
+
+import java.io.InputStream;
+import java.util.Map;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.BooleanLiteralExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.LongLiteralExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import org.drools.core.util.StringUtils;
+import org.jbpm.process.core.context.variable.VariableScope;
+import org.jbpm.ruleflow.core.factory.SubProcessNodeFactory;
+import org.jbpm.workflow.core.node.SubProcessNode;
+import org.kie.api.definition.process.Node;
+
+public class LambdaSubProcessNodeVisitor extends AbstractVisitor {
+
+    private final Map<String, ModelMetaData> processToModel;
+
+    public LambdaSubProcessNodeVisitor(Map<String, ModelMetaData> processToModel) {
+        this.processToModel = processToModel;
+    }
+
+    @Override
+    public void visitNode(Node node, BlockStmt body, VariableScope variableScope, ProcessMetaData metadata) {
+
+        InputStream resourceAsStream = this.getClass().getResourceAsStream("/class-templates/SubProcessFactoryTemplate.java");
+        Expression retValue = JavaParser.parse(resourceAsStream).findFirst(Expression.class).get();
+
+        SubProcessNode subProcessNode = (SubProcessNode) node;
+        String nodeVar = "subProcessNode" + node.getId();
+        addFactoryMethodWithArgsWithAssignment(body, SubProcessNodeFactory.class, nodeVar, "subProcessNode", new LongLiteralExpr(subProcessNode.getId()));
+        addFactoryMethodWithArgs(body, nodeVar, "name", new StringLiteralExpr(getOrDefault(subProcessNode.getName(), "Call Activity")));
+        addFactoryMethodWithArgs(body, nodeVar, "processId", new StringLiteralExpr(subProcessNode.getProcessId()));
+        addFactoryMethodWithArgs(body, nodeVar, "processName", new StringLiteralExpr(getOrDefault(subProcessNode.getProcessName(), "")));
+        addFactoryMethodWithArgs(body, nodeVar, "waitForCompletion", new BooleanLiteralExpr(subProcessNode.isWaitForCompletion()));
+        addFactoryMethodWithArgs(body, nodeVar, "independent", new BooleanLiteralExpr(subProcessNode.isIndependent()));
+
+        ModelMetaData subProcessModel = processToModel.get(subProcessNode.getProcessId());
+
+        retValue.findAll(ClassOrInterfaceType.class)
+                .stream()
+                .filter(t -> t.getNameAsString().equals("$Type$"))
+                .forEach(t -> t.setName(subProcessModel.getModelClassName()));
+
+        retValue.findFirst(MethodDeclaration.class, m -> m.getNameAsString().equals("bind"))
+                .ifPresent(m -> m.setBody(bind(variableScope, subProcessNode, subProcessModel)));
+        retValue.findFirst(MethodDeclaration.class, m -> m.getNameAsString().equals("createInstance"))
+                .ifPresent(m -> m.setBody(createInstance(subProcessNode)));
+        retValue.findFirst(MethodDeclaration.class, m -> m.getNameAsString().equals("unbind"))
+                .ifPresent(m -> m.setBody(unbind(variableScope, subProcessNode, subProcessModel)));
+
+        addFactoryMethodWithArgs(body, nodeVar, "subProcessFactory", retValue);
+        addFactoryMethodWithArgs(body, nodeVar, "done");
+    }
+
+    private BlockStmt bind(VariableScope variableScope, SubProcessNode subProcessNode, ModelMetaData subProcessModel) {
+        BlockStmt actionBody = new BlockStmt();
+        actionBody.addStatement(subProcessModel.newInstance("model"));
+
+        for (Map.Entry<String, String> e : subProcessNode.getInMappings().entrySet()) {
+            actionBody.addStatement(makeAssignment(variableScope.findVariable(e.getKey())));
+            actionBody.addStatement(subProcessModel.callSetter("model", e.getValue(), new NameExpr(e.getKey())));
+        }
+
+        actionBody.addStatement(new ReturnStmt(new NameExpr("model")));
+        return actionBody;
+    }
+
+    private BlockStmt createInstance(SubProcessNode subProcessNode) {
+
+        String processId = ProcessToExecModelGenerator.extractProcessId(subProcessNode.getProcessId());
+        String factoryMethodName = String.format("create%sProcess", StringUtils.capitalize(processId));
+
+        MethodCallExpr processSupplier = new MethodCallExpr(new NameExpr("module"), factoryMethodName);
+        MethodCallExpr processInstanceSupplier = new MethodCallExpr(processSupplier, "createInstance").addArgument("model");
+
+        return new BlockStmt().addStatement(new ReturnStmt(processInstanceSupplier));
+    }
+
+    private BlockStmt unbind(VariableScope variableScope, SubProcessNode subProcessNode, ModelMetaData subProcessModel) {
+        BlockStmt stmts = new BlockStmt();
+
+        for (Map.Entry<String, String> e : subProcessNode.getOutMappings().entrySet()) {
+            stmts.addStatement(makeAssignment(variableScope.findVariable(e.getKey())));
+            stmts.addStatement(new MethodCallExpr()
+                                       .setScope(new NameExpr("kcontext"))
+                                       .setName("setVariable")
+                                       .addArgument(new StringLiteralExpr(e.getValue()))
+                                       .addArgument(e.getKey()));
+        }
+
+        return stmts;
+    }
+}

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ModelMetaData.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ModelMetaData.java
@@ -16,46 +16,208 @@
 
 package org.jbpm.compiler.canonical;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.CastExpr;
+import com.github.javaparser.ast.expr.EnclosedExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.expr.ThisExpr;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import org.drools.core.util.StringUtils;
+import org.jbpm.process.core.context.variable.Variable;
+import org.jbpm.process.core.context.variable.VariableScope;
+
 public class ModelMetaData {
 
+    private final String packageName;
     private String modelClassSimpleName;
+    private final VariableScope variableScope;
     private String modelClassName;
 
-    private String generatedClassModel;
-
-    public ModelMetaData(String modelClassSimpleName, String modelClassName, String generatedClassModel) {
+    public ModelMetaData(String packageName, String modelClassSimpleName, VariableScope variableScope) {
+        this.packageName = packageName;
         this.modelClassSimpleName = modelClassSimpleName;
-        this.modelClassName = modelClassName;
-        this.generatedClassModel = generatedClassModel;
+        this.variableScope = variableScope;
+        this.modelClassName = packageName + '.' + modelClassSimpleName;
+    }
+
+    public String generate() {
+        CompilationUnit modelClass = compilationUnit();
+        return modelClass.toString();
+    }
+
+    public AssignExpr newInstance(String assignVarName) {
+        ClassOrInterfaceType type = new ClassOrInterfaceType(null, modelClassName);
+        return new AssignExpr(
+                new VariableDeclarationExpr(type, assignVarName),
+                new ObjectCreationExpr().setType(type),
+                AssignExpr.Operator.ASSIGN);
+    }
+
+    public MethodCallExpr fromMap(String varName, String mapVarName) {
+        return new MethodCallExpr(new NameExpr(varName), "fromMap").addArgument(mapVarName);
+    }
+
+    public MethodCallExpr toMap(String varName) {
+        return new MethodCallExpr(new NameExpr(varName), "toMap");
+    }
+
+    public BlockStmt copyInto(String sourceVarName, String destVarName, ModelMetaData dest, Map<String, String> mapping) {
+        BlockStmt blockStmt = new BlockStmt();
+
+        for (Map.Entry<String, String> e : mapping.entrySet()) {
+            String destField = e.getKey();
+            String sourceField = e.getValue();
+            blockStmt.addStatement(
+                    dest.callSetter(destVarName, destField, dest.callGetter(sourceVarName, sourceField)));
+        }
+
+        return blockStmt;
+    }
+
+    public MethodCallExpr callSetter(String targetVar, String destField, Expression value) {
+        Variable v = variableScope.findVariable(destField);
+        String setter = "set" + StringUtils.capitalize(v.getName()); // todo cache FieldDeclarations in compilationUnit()
+        return new MethodCallExpr(new NameExpr(targetVar), setter).addArgument(
+                new CastExpr(
+                        new ClassOrInterfaceType(null, v.getType().getStringType()),
+                        new EnclosedExpr(value)));
+    }
+
+    public MethodCallExpr callGetter(String targetVar, String field) {
+        Variable v = variableScope.findVariable(field);
+        String getter = "get" + StringUtils.capitalize(v.getName()); // todo cache FieldDeclarations in compilationUnit()
+        return new MethodCallExpr(new NameExpr(targetVar), getter);
+    }
+
+    private CompilationUnit compilationUnit() {
+        CompilationUnit compilationUnit = JavaParser.parse(this.getClass().getResourceAsStream("/class-templates/ModelTemplate.java"));
+        compilationUnit.setPackageDeclaration(packageName);
+        Optional<ClassOrInterfaceDeclaration> processMethod = compilationUnit.findFirst(ClassOrInterfaceDeclaration.class, sl1 -> true);
+
+        if (!processMethod.isPresent()) {
+            throw new RuntimeException("Cannot find class declaration in the template");
+        }
+        ClassOrInterfaceDeclaration modelClass = processMethod.get();
+
+        modelClass.setName(modelClassSimpleName);
+
+        // setup of the toMap method body
+        BlockStmt toMapBody = new BlockStmt();
+        ClassOrInterfaceType toMap = new ClassOrInterfaceType(null, new SimpleName(Map.class.getSimpleName()), NodeList.nodeList(new ClassOrInterfaceType(null, String.class.getSimpleName()), new ClassOrInterfaceType(null, Object.class.getSimpleName())));
+        VariableDeclarationExpr paramsField = new VariableDeclarationExpr(toMap, "params");
+        toMapBody.addStatement(new AssignExpr(paramsField, new ObjectCreationExpr(null, new ClassOrInterfaceType(null, HashMap.class.getSimpleName()), NodeList.nodeList()), AssignExpr.Operator.ASSIGN));
+
+        // setup of static fromMap method body
+        ClassOrInterfaceType modelType = new ClassOrInterfaceType(null, modelClass.getNameAsString());
+        BlockStmt staticFromMap = new BlockStmt();
+        VariableDeclarationExpr itemField = new VariableDeclarationExpr(modelType, "item");
+        staticFromMap.addStatement(new AssignExpr(itemField, new ObjectCreationExpr(null, modelType, NodeList.nodeList()), AssignExpr.Operator.ASSIGN));
+        NameExpr item = new NameExpr("item");
+        FieldAccessExpr idField = new FieldAccessExpr(item, "id");
+        staticFromMap.addStatement(new AssignExpr(idField, new NameExpr("id"), AssignExpr.Operator.ASSIGN));
+
+        // setup of non-static fromMap method body
+        BlockStmt fromMapBody = new BlockStmt();
+
+        for (Variable variable : variableScope.getVariables()) {
+
+            FieldDeclaration fd = declareField(variable);
+            modelClass.addMember(fd);
+
+            fd.createGetter();
+            fd.createSetter();
+
+            // toMap method body
+            MethodCallExpr putVariable = new MethodCallExpr(new NameExpr("params"), "put");
+            putVariable.addArgument(new StringLiteralExpr(variable.getName()));
+            putVariable.addArgument(new FieldAccessExpr(new ThisExpr(), variable.getName()));
+            toMapBody.addStatement(putVariable);
+
+            // fromMap static method body
+            FieldAccessExpr field = new FieldAccessExpr(item, variable.getName());
+
+            ClassOrInterfaceType type = JavaParser.parseClassOrInterfaceType(variable.getType().getStringType());
+            staticFromMap.addStatement(new AssignExpr(field, new CastExpr(
+                    type,
+                    new MethodCallExpr(
+                            new NameExpr("params"),
+                            "get")
+                            .addArgument(new StringLiteralExpr(variable.getName()))), AssignExpr.Operator.ASSIGN));
+
+            // from map instance method body
+            FieldAccessExpr instanceField = new FieldAccessExpr(new ThisExpr(), variable.getName());
+            fromMapBody.addStatement(new AssignExpr(instanceField, new CastExpr(
+                    type,
+                    new MethodCallExpr(
+                            new NameExpr("params"),
+                            "get")
+                            .addArgument(new StringLiteralExpr(variable.getName()))), AssignExpr.Operator.ASSIGN));
+        }
+
+        Optional<MethodDeclaration> toMapMethod = modelClass.findFirst(MethodDeclaration.class, sl -> sl.getName().asString().equals("toMap"));
+
+        toMapBody.addStatement(new ReturnStmt(new NameExpr("params")));
+        toMapMethod.get().setBody(toMapBody);
+
+        Optional<MethodDeclaration> staticFromMapMethod = modelClass.findFirst(
+                MethodDeclaration.class, sl -> sl.getName().asString().equals("fromMap") && sl.isStatic());
+        if (staticFromMapMethod.isPresent()) {
+            MethodDeclaration fromMap = staticFromMapMethod.get();
+            fromMap.setType(modelClass.getNameAsString());
+            staticFromMap.addStatement(new ReturnStmt(new NameExpr("item")));
+            fromMap.setBody(staticFromMap);
+        }
+
+        modelClass.findFirst(
+                MethodDeclaration.class, sl -> sl.getName().asString().equals("fromMap") && !sl.isStatic())
+                .ifPresent(m -> m.setBody(fromMapBody));
+
+        return compilationUnit;
+    }
+
+    private FieldDeclaration declareField(Variable variable) {
+        return new FieldDeclaration().addVariable(
+                new VariableDeclarator()
+                        .setType(variable.getType().getStringType())
+                        .setName(variable.getName()))
+                .addModifier(Modifier.Keyword.PRIVATE);
     }
 
     public String getModelClassSimpleName() {
         return modelClassSimpleName;
     }
 
-    public void setModelClassSimpleName(String modelClassSimpleName) {
-        this.modelClassSimpleName = modelClassSimpleName;
-    }
-
     public String getModelClassName() {
         return modelClassName;
     }
 
-    public void setModelClassName(String modelClassName) {
-        this.modelClassName = modelClassName;
-    }
-
     public String getGeneratedClassModel() {
-        return generatedClassModel;
-    }
-
-    public void setGeneratedClassModel(String generatedClassModel) {
-        this.generatedClassModel = generatedClassModel;
+        return generate();
     }
 
     @Override
     public String toString() {
         return "ModelMetaData [modelClassName=" + modelClassName + "]";
     }
-
 }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessMetaData.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessMetaData.java
@@ -19,6 +19,8 @@ package org.jbpm.compiler.canonical;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.github.javaparser.ast.CompilationUnit;
+
 public class ProcessMetaData {
 
     private String processClassName;
@@ -31,7 +33,7 @@ public class ProcessMetaData {
 
     private String processVersion;
 
-    private String generatedClassModel;
+    private CompilationUnit generatedClassModel;
 
     private Set<String> workItems = new HashSet<>();
 
@@ -84,11 +86,11 @@ public class ProcessMetaData {
         this.processVersion = processVersion;
     }
 
-    public String getGeneratedClassModel() {
+    public CompilationUnit getGeneratedClassModel() {
         return generatedClassModel;
     }
 
-    public void setGeneratedClassModel(String generatedClassModel) {
+    public void setGeneratedClassModel(CompilationUnit generatedClassModel) {
         this.generatedClassModel = generatedClassModel;
     }
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessToExecModelGenerator.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessToExecModelGenerator.java
@@ -17,6 +17,7 @@
 package org.jbpm.compiler.canonical;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -24,6 +25,22 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.BooleanLiteralExpr;
+import com.github.javaparser.ast.expr.LongLiteralExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import org.drools.core.util.StringUtils;
 import org.jbpm.process.core.ContextContainer;
 import org.jbpm.process.core.Work;
@@ -45,170 +62,93 @@ import org.kie.api.definition.process.Node;
 import org.kie.api.definition.process.NodeContainer;
 import org.kie.api.definition.process.WorkflowProcess;
 
-import com.github.javaparser.JavaParser;
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.Modifier.Keyword;
-import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.expr.AssignExpr;
-import com.github.javaparser.ast.expr.AssignExpr.Operator;
-import com.github.javaparser.ast.expr.BooleanLiteralExpr;
-import com.github.javaparser.ast.expr.CastExpr;
-import com.github.javaparser.ast.expr.FieldAccessExpr;
-import com.github.javaparser.ast.expr.LongLiteralExpr;
-import com.github.javaparser.ast.expr.MethodCallExpr;
-import com.github.javaparser.ast.expr.NameExpr;
-import com.github.javaparser.ast.expr.ObjectCreationExpr;
-import com.github.javaparser.ast.expr.SimpleName;
-import com.github.javaparser.ast.expr.StringLiteralExpr;
-import com.github.javaparser.ast.expr.ThisExpr;
-import com.github.javaparser.ast.expr.VariableDeclarationExpr;
-import com.github.javaparser.ast.stmt.BlockStmt;
-import com.github.javaparser.ast.stmt.ReturnStmt;
-import com.github.javaparser.ast.type.ClassOrInterfaceType;
-
 public class ProcessToExecModelGenerator extends AbstractVisitor {
 
-	public static final ProcessToExecModelGenerator INSTANCE = new ProcessToExecModelGenerator();
-	
-	
+	public static final ProcessToExecModelGenerator INSTANCE = new ProcessToExecModelGenerator(Collections.emptyMap());
+
+
 	private static final String PROCESS_CLASS_SUFFIX = "Process";
 	private static final String MODEL_CLASS_SUFFIX = "Model";
-	
+
 	private Map<Class<?>, AbstractVisitor> nodesVisitors = new HashMap<>();
-    
-	private ProcessToExecModelGenerator() {
-   
+
+	public ProcessToExecModelGenerator(Map<String, ModelMetaData> processToModel) {
+
 	    this.nodesVisitors.put(StartNode.class, new StartNodeVisitor());
 	    this.nodesVisitors.put(ActionNode.class, new ActionNodeVisitor());
 	    this.nodesVisitors.put(EndNode.class, new EndNodeVisitor());
 	    this.nodesVisitors.put(HumanTaskNode.class, new HumanTaskNodeVisitor());
 	    this.nodesVisitors.put(WorkItemNode.class, new WorkItemNodeVisitor());
-	    this.nodesVisitors.put(SubProcessNode.class, new SubProcessNodeVisitor());
+	    this.nodesVisitors.put(SubProcessNode.class, new LambdaSubProcessNodeVisitor(processToModel));
 	    this.nodesVisitors.put(Split.class, new SplitNodeVisitor());
 	    this.nodesVisitors.put(Join.class, new JoinNodeVisitor());
     }
 
     public ProcessMetaData generate(WorkflowProcess process) {
-        
-        CompilationUnit clazz = JavaParser.parse(this.getClass().getResourceAsStream("/class-templates/ProcessTemplate.java"));                
+
+        CompilationUnit clazz = JavaParser.parse(this.getClass().getResourceAsStream("/class-templates/ProcessTemplate.java"));
         clazz.setPackageDeclaration(process.getPackageName());
         Optional<ClassOrInterfaceDeclaration> processMethod = clazz.findFirst(ClassOrInterfaceDeclaration.class, sl -> true);
-        
-        String extractedProcessId = exctactProcessId(process.getId());
-        
+
+        String extractedProcessId = extractProcessId(process.getId());
+
         if (!processMethod.isPresent()) {
             throw new RuntimeException("Cannot find class declaration in the template");
         }
-        ClassOrInterfaceDeclaration processClazz = processMethod.get(); 
+        ClassOrInterfaceDeclaration processClazz = processMethod.get();
         processClazz.setName(StringUtils.capitalize(extractedProcessId + PROCESS_CLASS_SUFFIX));
-        ProcessMetaData metadata = new ProcessMetaData(process.getId(), 
-                                                       extractedProcessId, 
-                                                       process.getName(), 
+        ProcessMetaData metadata = new ProcessMetaData(process.getId(),
+                                                       extractedProcessId,
+                                                       process.getName(),
                                                        process.getVersion(),
                                                        (clazz.getPackageDeclaration().isPresent() ? clazz.getPackageDeclaration().get().getNameAsString() + "." : "") + processClazz.getNameAsString());
-              
-        visitProcess(process, clazz, metadata);
-        
-        metadata.setGeneratedClassModel(clazz.toString());
+
+        Optional<MethodDeclaration> pmethod = clazz.findFirst(MethodDeclaration.class, sl -> sl.getName().asString().equals("process"));
+
+        visitProcess(process, pmethod.get(), metadata);
+
+        metadata.setGeneratedClassModel(clazz);
         return metadata;
     }
-    
-    public ModelMetaData generateModel(WorkflowProcess process) {
-        CompilationUnit clazz = JavaParser.parse(this.getClass().getResourceAsStream("/class-templates/ModelTemplate.java"));                
+
+
+    public MethodDeclaration generateMethod(WorkflowProcess process) {
+
+        CompilationUnit clazz = JavaParser.parse(this.getClass().getResourceAsStream("/class-templates/ProcessTemplate.java"));
         clazz.setPackageDeclaration(process.getPackageName());
-        Optional<ClassOrInterfaceDeclaration> processMethod = clazz.findFirst(ClassOrInterfaceDeclaration.class, sl -> true);
 
-        if (!processMethod.isPresent()) {
-            throw new RuntimeException("Cannot find class declaration in the template");
-        }
-        ClassOrInterfaceDeclaration modelClass = processMethod.get();
-        
-        modelClass.setName(StringUtils.capitalize(exctactProcessId(process.getId()) + MODEL_CLASS_SUFFIX));
-    
-        // setup of the toMap method body
-        BlockStmt toMapBody = new BlockStmt();
-        ClassOrInterfaceType toMap = new ClassOrInterfaceType(null, new SimpleName(Map.class.getSimpleName()), NodeList.nodeList(new ClassOrInterfaceType(null, String.class.getSimpleName()), new ClassOrInterfaceType(null, Object.class.getSimpleName())));            
-        VariableDeclarationExpr paramsField = new VariableDeclarationExpr(toMap, "params");                                  
-        toMapBody.addStatement(new AssignExpr(paramsField, new ObjectCreationExpr(null, new ClassOrInterfaceType(null, HashMap.class.getSimpleName()), NodeList.nodeList()), AssignExpr.Operator.ASSIGN));
-        
-        // setup of fromMap method body
-        ClassOrInterfaceType modelType = new ClassOrInterfaceType(null, modelClass.getNameAsString());
-        BlockStmt fromMapBody = new BlockStmt();
-        VariableDeclarationExpr itemField = new VariableDeclarationExpr(modelType, "item");
-        fromMapBody.addStatement(new AssignExpr(itemField, new ObjectCreationExpr(null, modelType, NodeList.nodeList()), AssignExpr.Operator.ASSIGN));
-        NameExpr item = new NameExpr("item");
-        FieldAccessExpr idField = new FieldAccessExpr(item, "id");
-        fromMapBody.addStatement(new AssignExpr(idField, new NameExpr("id"), Operator.ASSIGN));
-        
-        VariableScope variableScope = (VariableScope) ((org.jbpm.process.core.Process) process).getDefaultContext(VariableScope.VARIABLE_SCOPE);
-        
-        if (variableScope != null && !variableScope.getVariables().isEmpty()) {
-            for (Variable variable: variableScope.getVariables()) {
-                ClassOrInterfaceType type = JavaParser.parseClassOrInterfaceType(variable.getType().getStringType());
-                
-                modelClass.addField(variable.getType().getStringType(), variable.getName(), Keyword.PRIVATE);
-                // getter
-                modelClass
-                .addMethod("get" + StringUtils.capitalize(variable.getName()), Keyword.PUBLIC)
-                .setType(type)
-                .createBody().addStatement(new ReturnStmt(new FieldAccessExpr(new ThisExpr(), variable.getName())));
-                
-                // setter
-                modelClass
-                .addMethod("set" + StringUtils.capitalize(variable.getName()), Keyword.PUBLIC)
-                .addParameter(variable.getType().getStringType(), variable.getName())
-                .createBody().addStatement( new AssignExpr(new FieldAccessExpr(new ThisExpr(), variable.getName()), new NameExpr(variable.getName()), Operator.ASSIGN));
-                
-                // toMap method body
-                MethodCallExpr putVariable = new MethodCallExpr(new NameExpr("params"), "put");
-                putVariable.addArgument(new StringLiteralExpr(variable.getName()));
-                putVariable.addArgument(new FieldAccessExpr(new ThisExpr(), variable.getName()));
-                toMapBody.addStatement(putVariable);
-                
-                // fromMap method body                    
-                FieldAccessExpr field = new FieldAccessExpr(item, variable.getName());
-                
-                fromMapBody.addStatement(new AssignExpr(field, new CastExpr(
-                                                                            type,
-                                                                            new MethodCallExpr(
-                                                                                    new NameExpr("params"),
-                                                                                    "get")
-                                                                                    .addArgument(new StringLiteralExpr(variable.getName()))), AssignExpr.Operator.ASSIGN));
-            }
-        }
-        
-        Optional<MethodDeclaration> toMapMethod = clazz.findFirst(MethodDeclaration.class, sl -> sl.getName().asString().equals("toMap"));
-        if (processMethod.isPresent()) {
-            
-            toMapBody.addStatement(new ReturnStmt(new NameExpr("params")));
-            toMapMethod.get().setBody(toMapBody);
-        }
-        
-        Optional<MethodDeclaration> fromMapMethod = clazz.findFirst(MethodDeclaration.class, sl -> sl.getName().asString().equals("fromMap"));
-        if (fromMapMethod.isPresent()) {
-            MethodDeclaration fromMap = fromMapMethod.get();
-            fromMap.setType(modelClass.getNameAsString());
-            fromMapBody.addStatement(new ReturnStmt(new NameExpr("item")));
-            fromMap.setBody(fromMapBody);
-        }
-        String fqcn = clazz.getPackageDeclaration().map(p -> p.getNameAsString() + "." + modelClass.getNameAsString()).orElse(modelClass.getNameAsString());
-        
-        return new ModelMetaData(modelClass.getNameAsString(), fqcn, clazz.toString());
-    }	
+        String extractedProcessId = extractProcessId(process.getId());
 
-	protected void visitProcess(WorkflowProcess process, CompilationUnit clazz, ProcessMetaData metadata) {
+        ProcessMetaData metadata = new ProcessMetaData(process.getId(),
+                                                       extractedProcessId,
+                                                       process.getName(),
+                                                       process.getVersion(),
+                                                       (clazz.getPackageDeclaration().isPresent() ? clazz.getPackageDeclaration().get().getNameAsString() + "." : "") + "process");
+
+        MethodDeclaration processMethod = new MethodDeclaration();
+        visitProcess(process, processMethod, metadata);
+
+        return processMethod;
+    }
+
+    public ModelMetaData generateModel(WorkflowProcess process) {
+        String packageName = process.getPackageName();
+        String name = StringUtils.capitalize(extractProcessId(process.getId()) + MODEL_CLASS_SUFFIX);
+
+        return new ModelMetaData(packageName, name, (VariableScope) ((org.jbpm.process.core.Process) process).getDefaultContext(VariableScope.VARIABLE_SCOPE));
+    }
+
+	protected void visitProcess(WorkflowProcess process, MethodDeclaration processMethod, ProcessMetaData metadata) {
         BlockStmt body = new BlockStmt();
-        
+
         ClassOrInterfaceType processFactoryType = new ClassOrInterfaceType(null, RuleFlowProcessFactory.class.getSimpleName());
-        
+
         // create local variable factory and assign new fluent process to it
-        VariableDeclarationExpr factoryField = new VariableDeclarationExpr(processFactoryType, FACTORY_FIELD_NAME);        
+        VariableDeclarationExpr factoryField = new VariableDeclarationExpr(processFactoryType, FACTORY_FIELD_NAME);
         MethodCallExpr assignFactoryMethod = new MethodCallExpr(new NameExpr(processFactoryType.getName().asString()), "createProcess");
-        assignFactoryMethod.addArgument(new StringLiteralExpr(process.getId()));                
+        assignFactoryMethod.addArgument(new StringLiteralExpr(process.getId()));
         body.addStatement(new AssignExpr(factoryField, assignFactoryMethod, AssignExpr.Operator.ASSIGN));
-        
+
     	// item definitions
         Set<String> visitedVariables = new HashSet<String>();
     	VariableScope variableScope = (VariableScope) ((org.jbpm.process.core.Process) process).getDefaultContext(VariableScope.VARIABLE_SCOPE);
@@ -224,51 +164,46 @@ public class ProcessToExecModelGenerator extends AbstractVisitor {
 	    addFactoryMethodWithArgs(body, "dynamic", new BooleanLiteralExpr(((org.jbpm.workflow.core.WorkflowProcess) process).isDynamic()));
 	    addFactoryMethodWithArgs(body, "version", new StringLiteralExpr(getOrDefault(process.getVersion(), "1.0")));
 	    addFactoryMethodWithArgs(body, "visibility", new StringLiteralExpr(getOrDefault(((org.jbpm.workflow.core.WorkflowProcess) process).getVisibility(), WorkflowProcess.PUBLIC_VISIBILITY)));
-	    
+
 	    visitMetaData(process.getMetaData(), body, FACTORY_FIELD_NAME);
 
         visitHeader(process, body);
-        
+
         List<org.jbpm.workflow.core.Node> processNodes = new ArrayList<org.jbpm.workflow.core.Node>();
-        for( Node procNode : process.getNodes()) { 
+        for( Node procNode : process.getNodes()) {
             processNodes.add((org.jbpm.workflow.core.Node) procNode);
         }
         visitNodes(processNodes, body, variableScope, metadata);
         visitConnections(process.getNodes(), body);
-        
+
 
         addFactoryMethodWithArgs(body, "validate");
-        
-    	Optional<MethodDeclaration> processMethod = clazz.findFirst(MethodDeclaration.class, sl -> sl.getName().asString().equals("process"));
 
-    	if (processMethod.isPresent()) {
-    	    
-    	    MethodCallExpr getProcessMethod = new MethodCallExpr(new NameExpr(FACTORY_FIELD_NAME), "getProcess");
-    	    body.addStatement(new ReturnStmt(getProcessMethod));
-    	    processMethod.get().setBody(body);
-    	}
-        
+        MethodCallExpr getProcessMethod = new MethodCallExpr(new NameExpr(FACTORY_FIELD_NAME), "getProcess");
+        body.addStatement(new ReturnStmt(getProcessMethod));
+        processMethod.setBody(body);
+
     }
 
     private void visitVariableScope(VariableScope variableScope, BlockStmt body, Set<String> visitedVariables) {
         if (variableScope != null && !variableScope.getVariables().isEmpty()) {
             for (Variable variable: variableScope.getVariables()) {
-                
-                if( !visitedVariables.add(variable.getName()) ) { 
+
+                if( !visitedVariables.add(variable.getName()) ) {
                     continue;
                 }
                 ClassOrInterfaceType variableType = new ClassOrInterfaceType(null, ObjectDataType.class.getSimpleName());
                 ObjectCreationExpr variableValue = new ObjectCreationExpr(null, variableType, new NodeList<>(new StringLiteralExpr(variable.getType().getStringType())));
-                addFactoryMethodWithArgs(body, "variable", new StringLiteralExpr(variable.getName()), variableValue);                
+                addFactoryMethodWithArgs(body, "variable", new StringLiteralExpr(variable.getName()), variableValue);
             }
-            
+
         }
     }
 
     private void visitSubVariableScopes(Node[] nodes, BlockStmt body, Set<String> visitedVariables) {
         for (Node node: nodes) {
             if (node instanceof ContextContainer) {
-                VariableScope variableScope = (VariableScope) 
+                VariableScope variableScope = (VariableScope)
                     ((ContextContainer) node).getDefaultContext(VariableScope.VARIABLE_SCOPE);
                 if (variableScope != null) {
                     visitVariableScope(variableScope, body, visitedVariables);
@@ -284,25 +219,25 @@ public class ProcessToExecModelGenerator extends AbstractVisitor {
         Map<String, Object> metaData = getMetaData(process.getMetaData());
     	Set<String> imports = ((org.jbpm.process.core.Process) process).getImports();
     	Map<String, String> globals = ((org.jbpm.process.core.Process) process).getGlobals();
-    	if ((imports != null && !imports.isEmpty()) || (globals != null && globals.size() > 0) || !metaData.isEmpty()) {    		
+    	if ((imports != null && !imports.isEmpty()) || (globals != null && globals.size() > 0) || !metaData.isEmpty()) {
     		if (imports != null) {
-	    		for (String s: imports) {	    			
+	    		for (String s: imports) {
 	    			addFactoryMethodWithArgs(body, "imports", new StringLiteralExpr(s));
 	    		}
     		}
     		if (globals != null) {
-	    		for (Map.Entry<String, String> global: globals.entrySet()) {	    			
+	    		for (Map.Entry<String, String> global: globals.entrySet()) {
 	    			addFactoryMethodWithArgs(body, "global", new StringLiteralExpr(global.getKey()), new StringLiteralExpr(global.getValue()));
 	    		}
     		}
-    	}        
+    	}
     }
 
     public static Map<String, Object> getMetaData(Map<String, Object> input) {
     	Map<String, Object> metaData = new HashMap<String, Object>();
         for (Map.Entry<String, Object> entry: input.entrySet()) {
         	String name = entry.getKey();
-        	if (entry.getKey().startsWith("custom") 
+        	if (entry.getKey().startsWith("custom")
         			&& entry.getValue() instanceof String) {
         		metaData.put(name, entry.getValue());
         	}
@@ -321,21 +256,21 @@ public class ProcessToExecModelGenerator extends AbstractVisitor {
     }
 
     public void visitNodes(List<org.jbpm.workflow.core.Node> nodes, BlockStmt body, VariableScope variableScope, ProcessMetaData metadata) {
-    	
+
         for (Node node: nodes) {
             AbstractVisitor visitor = nodesVisitors.get(node.getClass());
-            
+
             if (visitor == null) {
                 throw new IllegalStateException("No visitor found for node " + node.getClass().getName());
             }
-            
+
             visitor.visitNode(node, body, variableScope, metadata);
         }
-        
+
     }
 
     private void visitConnections(Node[] nodes, BlockStmt body) {
-    	
+
         List<Connection> connections = new ArrayList<Connection>();
         for (Node node: nodes) {
             for (List<Connection> connectionList: node.getIncomingConnections().values()) {
@@ -345,7 +280,7 @@ public class ProcessToExecModelGenerator extends AbstractVisitor {
         for (Connection connection: connections) {
             visitConnection(connection, body);
         }
-        
+
     }
 
     private boolean isConnectionRepresentingLinkEvent(Connection connection) {
@@ -360,24 +295,24 @@ public class ProcessToExecModelGenerator extends AbstractVisitor {
         }
         // if the connection is a hidden one (compensations), don't dump
         Object hidden = ((ConnectionImpl) connection).getMetaData("hidden");
-        if( hidden != null && ((Boolean) hidden) ) { 
-           return; 
+        if( hidden != null && ((Boolean) hidden) ) {
+           return;
         }
-         
-        addFactoryMethodWithArgs(body, "connection", new LongLiteralExpr(connection.getFrom().getId()), 
-                                 new LongLiteralExpr(connection.getTo().getId()), 
-                                 new StringLiteralExpr(getOrDefault((String) ((ConnectionImpl) connection).getMetaData().get("UniqueId"),  "")));        
+
+        addFactoryMethodWithArgs(body, "connection", new LongLiteralExpr(connection.getFrom().getId()),
+                                 new LongLiteralExpr(connection.getTo().getId()),
+                                 new StringLiteralExpr(getOrDefault((String) ((ConnectionImpl) connection).getMetaData().get("UniqueId"),  "")));
     }
-    
-    
-    
-    public String exctactProcessId(String processId) {
+
+
+
+    public static String extractProcessId(String processId) {
         if (processId.contains(".")) {
             return processId.substring(processId.lastIndexOf(".") + 1);
         }
-        
+
         return processId;
     }
 
-    
+
 }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/SubProcessNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/SubProcessNodeVisitor.java
@@ -39,14 +39,14 @@ public class SubProcessNodeVisitor extends AbstractVisitor {
         addFactoryMethodWithArgs(body, "subProcessNode" + node.getId(), "processName", new StringLiteralExpr(getOrDefault(subProcessNode.getProcessName(), "")));
         addFactoryMethodWithArgs(body, "subProcessNode" + node.getId(), "waitForCompletion", new BooleanLiteralExpr(subProcessNode.isWaitForCompletion()));
         addFactoryMethodWithArgs(body, "subProcessNode" + node.getId(), "independent", new BooleanLiteralExpr(subProcessNode.isIndependent()));
-        
+
         for (Entry<String, String> entry : subProcessNode.getInMappings().entrySet()) {
             addFactoryMethodWithArgs(body, "subProcessNode" + node.getId(), "inMapping", new StringLiteralExpr(entry.getKey()), new StringLiteralExpr(entry.getValue()));
         }
         for (Entry<String, String> entry : subProcessNode.getOutMappings().entrySet()) {
             addFactoryMethodWithArgs(body, "subProcessNode" + node.getId(), "outMapping", new StringLiteralExpr(entry.getKey()), new StringLiteralExpr(entry.getValue()));
         }
-        
+
         addFactoryMethodWithArgs(body, "subProcessNode" + node.getId(), "done");
     }
 }

--- a/jbpm/jbpm-flow-builder/src/main/resources/class-templates/ModelTemplate.java
+++ b/jbpm/jbpm-flow-builder/src/main/resources/class-templates/ModelTemplate.java
@@ -21,6 +21,10 @@ public class XXXModel {
         
     }
 
+    public void fromMap(Map<String, Object> params) {
+
+    }
+
     public static XXXModel fromMap(Long id, Map<String, Object> params) {
         
     }

--- a/jbpm/jbpm-flow-builder/src/main/resources/class-templates/SubProcessFactoryTemplate.java
+++ b/jbpm/jbpm-flow-builder/src/main/resources/class-templates/SubProcessFactoryTemplate.java
@@ -1,0 +1,13 @@
+class Template {
+    Object f = new org.jbpm.workflow.core.node.SubProcessFactory<$Type$>() {
+        public $Type$ bind(org.kie.api.runtime.process.ProcessContext kcontext) {
+            return null;
+        }
+        public org.kie.submarine.process.ProcessInstance<$Type$> createInstance($Type$ model) {
+            return null;
+        }
+        public void unbind(org.kie.api.runtime.process.ProcessContext kcontext, $Type$ model) {
+
+        }
+    };
+}

--- a/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/compiler/canonical/ProcessToExecModelGeneratorTest.java
+++ b/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/compiler/canonical/ProcessToExecModelGeneratorTest.java
@@ -66,7 +66,7 @@ public class ProcessToExecModelGeneratorTest {
         ProcessMetaData processMetadata = ProcessToExecModelGenerator.INSTANCE.generate((WorkflowProcess) process);
         assertNotNull("Dumper should return non null class for process", processMetadata);
         
-        logger.debug(processMetadata.getGeneratedClassModel());
+        logger.debug(processMetadata.getGeneratedClassModel().toString());
         
         assertEquals("orders", processMetadata.getExtractedProcessId());
         assertEquals("demo.orders", processMetadata.getProcessId());

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/AbstractProcessRuntimeServiceProvider.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/AbstractProcessRuntimeServiceProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.process.instance;
+
+import java.util.Optional;
+
+import org.jbpm.process.instance.impl.DefaultProcessInstanceManager;
+import org.kie.api.runtime.process.WorkItemManager;
+import org.kie.services.signal.LightSignalManager;
+import org.kie.services.signal.SignalManager;
+import org.kie.services.time.TimerService;
+import org.kie.submarine.process.WorkItemHandlerConfig;
+
+public class AbstractProcessRuntimeServiceProvider implements ProcessRuntimeServiceProvider {
+
+    private final TimerService timerService;
+    private final ProcessInstanceManager processInstanceManager;
+    private final SignalManager signalManager;
+    private final WorkItemManager workItemManager;
+
+    public AbstractProcessRuntimeServiceProvider(
+            TimerService timerService,
+            WorkItemHandlerConfig workItemHandlerProvider) {
+        processInstanceManager = new DefaultProcessInstanceManager();
+        signalManager = new LightSignalManager(
+                id -> Optional.ofNullable(
+                        processInstanceManager.getProcessInstance(id)));
+        this.timerService = timerService;
+        this.workItemManager = new LightWorkItemManager(processInstanceManager, signalManager);
+
+        for (String workItem : workItemHandlerProvider.names()) {
+            workItemManager.registerWorkItemHandler(
+                    workItem, workItemHandlerProvider.forName(workItem));
+        }
+    }
+
+    @Override
+    public TimerService getTimerService() {
+        return timerService;
+    }
+
+    @Override
+    public ProcessInstanceManager getProcessInstanceManager() {
+        return processInstanceManager;
+    }
+
+    @Override
+    public SignalManager getSignalManager() {
+        return signalManager;
+    }
+
+    @Override
+    public WorkItemManager getWorkItemManager() {
+        return workItemManager;
+    }
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/DummyKnowledgeRuntime.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/DummyKnowledgeRuntime.java
@@ -9,7 +9,7 @@ import org.drools.core.common.InternalKnowledgeRuntime;
 import org.drools.core.common.WorkingMemoryAction;
 import org.drools.core.impl.EnvironmentImpl;
 import org.drools.core.runtime.process.InternalProcessRuntime;
-import org.kie.services.time.TimerService;
+import org.jbpm.workflow.instance.impl.CodegenNodeInstanceFactoryRegistry;
 import org.kie.api.KieBase;
 import org.kie.api.event.process.ProcessEventListener;
 import org.kie.api.event.rule.AgendaEventListener;
@@ -29,6 +29,7 @@ import org.kie.api.runtime.rule.LiveQuery;
 import org.kie.api.runtime.rule.QueryResults;
 import org.kie.api.runtime.rule.ViewChangedEventListener;
 import org.kie.api.time.SessionClock;
+import org.kie.services.time.TimerService;
 
 /**
  * A severely limited implementation of the WorkingMemory interface.
@@ -38,10 +39,14 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime {
 
     private final EnvironmentImpl environment;
     private InternalProcessRuntime processRuntime;
+    private final WorkItemManager workItemManager;
 
-    DummyKnowledgeRuntime(InternalProcessRuntime processRuntime) {
-        environment = new EnvironmentImpl();
+    DummyKnowledgeRuntime(InternalProcessRuntime processRuntime, WorkItemManager workItemManager) {
         this.processRuntime = processRuntime;
+        this.workItemManager = workItemManager;
+        this.environment = new EnvironmentImpl();
+        // register codegen-based node instances factories
+        environment.set("NodeInstanceFactoryRegistry", new CodegenNodeInstanceFactoryRegistry());
     }
 
     @Override
@@ -73,7 +78,6 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime {
     public InternalProcessRuntime getProcessRuntime() {
         return this.processRuntime;
     }
-
 
     @Override
     public Environment getEnvironment() {
@@ -252,7 +256,7 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime {
 
     @Override
     public WorkItemManager getWorkItemManager() {
-        return null;
+        return workItemManager;
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntimeContext.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntimeContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jbpm.process.instance;
 
 import java.util.Collection;
@@ -68,8 +83,7 @@ public class LightProcessRuntimeContext implements ProcessRuntimeContext {
     @Override
     public ProcessInstance createProcessInstance(
             Process process,
-            CorrelationKey correlationKey,
-            Map<String, Object> parameters) {
+            CorrelationKey correlationKey) {
 
         RuleFlowProcessInstance processInstance = new RuleFlowProcessInstance();
         processInstance.setProcess(process);
@@ -78,6 +92,12 @@ public class LightProcessRuntimeContext implements ProcessRuntimeContext {
             processInstance.getMetaData().put("CorrelationKey", correlationKey);
         }
 
+        return processInstance;
+    }
+
+    @Override
+    public void setupParameters(ProcessInstance processInstance, Map<String, Object> parameters) {
+        Process process = processInstance.getProcess();
         // set variable default values
         // TODO: should be part of processInstanceImpl?
         VariableScope variableScope = (VariableScope) ((ContextContainer) process).getDefaultContext(VariableScope.VARIABLE_SCOPE);
@@ -95,6 +115,5 @@ public class LightProcessRuntimeContext implements ProcessRuntimeContext {
             }
         }
 
-        return processInstance;
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntimeServiceProvider.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntimeServiceProvider.java
@@ -1,40 +1,27 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jbpm.process.instance;
 
-import java.util.Optional;
-
-import org.jbpm.process.instance.impl.DefaultProcessInstanceManager;
-import org.kie.services.signal.LightSignalManager;
-import org.kie.services.signal.SignalManager;
-import org.kie.services.time.TimerService;
 import org.kie.services.time.impl.JDKTimerService;
+import org.kie.submarine.process.impl.DefaultWorkItemHandlerConfig;
 
-public class LightProcessRuntimeServiceProvider implements ProcessRuntimeServiceProvider {
-
-    private final TimerService timerService;
-    private final ProcessInstanceManager processInstanceManager;
-    private final SignalManager signalManager;
+public class LightProcessRuntimeServiceProvider extends AbstractProcessRuntimeServiceProvider {
 
     public LightProcessRuntimeServiceProvider() {
-        timerService = new JDKTimerService();
-        processInstanceManager = new DefaultProcessInstanceManager();
-        signalManager = new LightSignalManager(
-                id -> Optional.ofNullable(
-                        processInstanceManager.getProcessInstance(id)));
+        super(new JDKTimerService(),
+              new DefaultWorkItemHandlerConfig());
     }
-
-    @Override
-    public TimerService getTimerService() {
-        return timerService;
-    }
-
-    @Override
-    public ProcessInstanceManager getProcessInstanceManager() {
-        return processInstanceManager;
-    }
-
-    @Override
-    public SignalManager getSignalManager() {
-        return signalManager;
-    }
-
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightTimerManagerRuntime.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightTimerManagerRuntime.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jbpm.process.instance;
 
 import java.util.Map;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightWorkItemManager.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightWorkItemManager.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.process.instance;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.drools.core.WorkItemHandlerNotFoundException;
+import org.drools.core.process.instance.WorkItem;
+import org.drools.core.process.instance.WorkItemManager;
+import org.drools.core.process.instance.impl.WorkItemImpl;
+import org.kie.api.runtime.process.ProcessInstance;
+import org.kie.api.runtime.process.WorkItemHandler;
+import org.kie.internal.runtime.Closeable;
+import org.kie.services.signal.SignalManager;
+
+public class LightWorkItemManager implements WorkItemManager{
+
+    private static final long serialVersionUID = 510l;
+
+    private AtomicLong workItemCounter = new AtomicLong(0);
+    private Map<Long, WorkItem> workItems = new ConcurrentHashMap<Long, WorkItem>();
+    private Map<String, WorkItemHandler> workItemHandlers = new HashMap<String, WorkItemHandler>();
+
+    private final ProcessInstanceManager processInstanceManager;
+    private final SignalManager signalManager;
+
+    public LightWorkItemManager(ProcessInstanceManager processInstanceManager, SignalManager signalManager) {
+        this.processInstanceManager = processInstanceManager;
+        this.signalManager = signalManager;
+    }
+
+    public void internalExecuteWorkItem(WorkItem workItem) {
+        ((WorkItemImpl) workItem).setId(workItemCounter.incrementAndGet());
+        internalAddWorkItem(workItem);
+        WorkItemHandler handler = this.workItemHandlers.get(workItem.getName());
+        if (handler != null) {
+            handler.executeWorkItem(workItem, this);
+        } else throw new WorkItemHandlerNotFoundException( "Could not find work item handler for " + workItem.getName(),
+                                                    workItem.getName() );
+    }
+
+    public void internalAddWorkItem(WorkItem workItem) {
+        workItems.put(workItem.getId(), workItem);
+        // fix to reset workItemCounter after deserialization
+        if (workItem.getId() > workItemCounter.get()) {
+            workItemCounter.set(workItem.getId());
+        }
+    }
+
+    public void internalAbortWorkItem(long id) {
+        WorkItemImpl workItem = (WorkItemImpl) workItems.get(id);
+        // work item may have been aborted
+        if (workItem != null) {
+            WorkItemHandler handler = this.workItemHandlers.get(workItem.getName());
+            if (handler != null) {
+                handler.abortWorkItem(workItem, this);
+            } else {
+                workItems.remove( workItem.getId() );
+                throw new WorkItemHandlerNotFoundException( "Could not find work item handler for " + workItem.getName(),
+                                                                 workItem.getName() );
+            }
+            workItems.remove(workItem.getId());
+        }
+    }
+
+    public WorkItemHandler getWorkItemHandler(String name) {
+    	return this.workItemHandlers.get(name);
+    }
+
+    public void retryWorkItem(long workItemId) {
+    	WorkItem workItem = workItems.get(workItemId);
+    	retryWorkItem(workItem);
+    }
+
+    public void retryWorkItemWithParams(long workItemId,Map<String,Object> map) {
+        WorkItem workItem = workItems.get(workItemId);
+        
+        if ( workItem != null ) {
+            workItem.setParameters( map );
+            
+            retryWorkItem( workItem );
+        }
+    }
+    
+    private void retryWorkItem(WorkItem workItem) {
+        if (workItem != null) {
+            WorkItemHandler handler = this.workItemHandlers.get(workItem.getName());
+            if (handler != null) {
+                handler.executeWorkItem(workItem, this);
+            } else throw new WorkItemHandlerNotFoundException( "Could not find work item handler for " + workItem.getName(),
+                                                        workItem.getName() );
+        }
+    }
+    
+    public Set<WorkItem> getWorkItems() {
+        return new HashSet<WorkItem>(workItems.values());
+    }
+
+    public WorkItem getWorkItem(long id) {
+        return workItems.get(id);
+    }
+
+    public void completeWorkItem(long id, Map<String, Object> results) {
+        WorkItem workItem = workItems.get(id);
+        // work item may have been aborted
+        if (workItem != null) {
+            (workItem).setResults(results);
+            ProcessInstance processInstance = processInstanceManager.getProcessInstance(workItem.getProcessInstanceId());
+            (workItem).setState(WorkItem.COMPLETED);
+            // process instance may have finished already
+            if (processInstance != null) {
+                processInstance.signalEvent("workItemCompleted", workItem);
+            }
+            workItems.remove(id);
+        }
+    }
+
+    public void abortWorkItem(long id) {
+        WorkItemImpl workItem = (WorkItemImpl) workItems.get(id);
+        // work item may have been aborted
+        if (workItem != null) {
+            ProcessInstance processInstance = processInstanceManager.getProcessInstance(workItem.getProcessInstanceId());
+            workItem.setState(WorkItem.ABORTED);
+            // process instance may have finished already
+            if (processInstance != null) {
+                processInstance.signalEvent("workItemAborted", workItem);
+            }
+            workItems.remove(id);
+        }
+    }
+
+    public void registerWorkItemHandler(String workItemName, WorkItemHandler handler) {
+        this.workItemHandlers.put(workItemName, handler);
+    }
+
+    public void clear() {
+        this.workItems.clear();
+    }
+    
+    public void signalEvent(String type, Object event) { 
+        this.signalManager.signalEvent(type, event);
+    } 
+    
+    public void signalEvent(String type, Object event, long processInstanceId) { 
+        this.signalManager.signalEvent(processInstanceId, type, event);
+    }
+
+    @Override
+    public void dispose() {
+        if (workItemHandlers != null) {
+            for (Map.Entry<String, WorkItemHandler> handlerEntry : workItemHandlers.entrySet()) {
+                if (handlerEntry.getValue() instanceof Closeable) {
+                    ((Closeable) handlerEntry.getValue()).close();
+                }
+            }
+        }
+    }
+    
+    @Override
+    public void retryWorkItem( Long workItemID, Map<String, Object> params ) {
+       if(params==null || params.isEmpty()){
+           retryWorkItem(workItemID);
+       }else{
+           this.retryWorkItemWithParams( workItemID, params );
+       }
+        
+    }
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessRuntimeContext.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessRuntimeContext.java
@@ -30,6 +30,7 @@ public interface ProcessRuntimeContext {
 
     ProcessInstance createProcessInstance(
             Process process,
-            CorrelationKey correlationKey,
-            Map<String, Object> parameters);
+            CorrelationKey correlationKey);
+
+    void setupParameters(ProcessInstance pi, Map<String, Object> parameters);
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessRuntimeServiceProvider.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessRuntimeServiceProvider.java
@@ -1,7 +1,9 @@
 package org.jbpm.process.instance;
 
+import org.kie.api.runtime.process.WorkItemManager;
 import org.kie.services.time.TimerService;
 import org.kie.services.signal.SignalManager;
+import org.kie.submarine.process.WorkItemHandlerConfig;
 
 public interface ProcessRuntimeServiceProvider {
 
@@ -10,4 +12,6 @@ public interface ProcessRuntimeServiceProvider {
     ProcessInstanceManager getProcessInstanceManager();
 
     SignalManager getSignalManager();
+
+    WorkItemManager getWorkItemManager();
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/SubProcessNodeFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/SubProcessNodeFactory.java
@@ -18,6 +18,8 @@ package org.jbpm.ruleflow.core.factory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 import org.jbpm.process.core.timer.Timer;
 import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
@@ -26,7 +28,10 @@ import org.jbpm.workflow.core.Node;
 import org.jbpm.workflow.core.NodeContainer;
 import org.jbpm.workflow.core.impl.DroolsConsequenceAction;
 import org.jbpm.workflow.core.node.MilestoneNode;
+import org.jbpm.workflow.core.node.SubProcessFactory;
 import org.jbpm.workflow.core.node.SubProcessNode;
+import org.kie.api.runtime.process.ProcessContext;
+import org.kie.submarine.process.ProcessInstance;
 
 /**
  *
@@ -40,9 +45,9 @@ public class SubProcessNodeFactory extends NodeFactory {
     protected Node createNode() {
         return new SubProcessNode();
     }
-    
+
     protected SubProcessNode getSubProcessNode() {
-    	return (SubProcessNode) getNode();
+        return (SubProcessNode) getNode();
     }
 
     public SubProcessNodeFactory name(String name) {
@@ -51,38 +56,38 @@ public class SubProcessNodeFactory extends NodeFactory {
     }
 
     public SubProcessNodeFactory processId(final String processId) {
-    	getSubProcessNode().setProcessId(processId);
+        getSubProcessNode().setProcessId(processId);
         return this;
     }
-    
+
     public SubProcessNodeFactory processName(final String processName) {
         getSubProcessNode().setProcessName(processName);
         return this;
     }
 
     public SubProcessNodeFactory waitForCompletion(boolean waitForCompletion) {
-    	getSubProcessNode().setWaitForCompletion(waitForCompletion);
+        getSubProcessNode().setWaitForCompletion(waitForCompletion);
         return this;
     }
 
     public SubProcessNodeFactory inMapping(String parameterName, String variableName) {
-    	getSubProcessNode().addInMapping(parameterName, variableName);
+        getSubProcessNode().addInMapping(parameterName, variableName);
         return this;
     }
 
     public SubProcessNodeFactory outMapping(String parameterName, String variableName) {
-    	getSubProcessNode().addOutMapping(parameterName, variableName);
+        getSubProcessNode().addOutMapping(parameterName, variableName);
         return this;
     }
 
     public SubProcessNodeFactory independent(boolean independent) {
-    	getSubProcessNode().setIndependent(independent);
+        getSubProcessNode().setIndependent(independent);
         return this;
     }
 
     public SubProcessNodeFactory onEntryAction(String dialect, String action) {
         if (getSubProcessNode().getActions(dialect) != null) {
-        	getSubProcessNode().getActions(dialect).add(new DroolsConsequenceAction(dialect, action));
+            getSubProcessNode().getActions(dialect).add(new DroolsConsequenceAction(dialect, action));
         } else {
             List<DroolsAction> actions = new ArrayList<DroolsAction>();
             actions.add(new DroolsConsequenceAction(dialect, action));
@@ -93,7 +98,7 @@ public class SubProcessNodeFactory extends NodeFactory {
 
     public SubProcessNodeFactory onExitAction(String dialect, String action) {
         if (getSubProcessNode().getActions(dialect) != null) {
-        	getSubProcessNode().getActions(dialect).add(new DroolsConsequenceAction(dialect, action));
+            getSubProcessNode().getActions(dialect).add(new DroolsConsequenceAction(dialect, action));
         } else {
             List<DroolsAction> actions = new ArrayList<DroolsAction>();
             actions.add(new DroolsConsequenceAction(dialect, action));
@@ -103,11 +108,15 @@ public class SubProcessNodeFactory extends NodeFactory {
     }
 
     public SubProcessNodeFactory timer(String delay, String period, String dialect, String action) {
-    	Timer timer = new Timer();
-    	timer.setDelay(delay);
-    	timer.setPeriod(period);
-    	getSubProcessNode().addTimer(timer, new DroolsConsequenceAction(dialect, action));
-    	return this;
+        Timer timer = new Timer();
+        timer.setDelay(delay);
+        timer.setPeriod(period);
+        getSubProcessNode().addTimer(timer, new DroolsConsequenceAction(dialect, action));
+        return this;
     }
-    
+
+    public <T> SubProcessNodeFactory subProcessFactory(SubProcessFactory<T> factory) {
+        getSubProcessNode().setSubProcessFactory(factory);
+        return this;
+    }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/SubProcessFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/SubProcessFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.workflow.core.node;
+
+import org.kie.api.runtime.process.ProcessContext;
+import org.kie.submarine.process.ProcessInstance;
+
+public interface SubProcessFactory<T> {
+    T bind(ProcessContext ctx);
+    ProcessInstance<T> createInstance(T model);
+    void unbind(ProcessContext ctx, T model);
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/SubProcessNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/SubProcessNode.java
@@ -22,6 +22,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 import org.kie.api.definition.process.Connection;
 import org.jbpm.process.core.Context;
@@ -29,7 +31,8 @@ import org.jbpm.process.core.ContextContainer;
 import org.jbpm.process.core.context.AbstractContext;
 import org.jbpm.process.core.context.variable.Mappable;
 import org.jbpm.process.core.impl.ContextContainerImpl;
-
+import org.kie.api.runtime.process.ProcessContext;
+import org.kie.submarine.process.ProcessInstance;
 
 /**
  * Default implementation of a sub-flow node.
@@ -49,7 +52,8 @@ public class SubProcessNode extends StateBasedNode implements Mappable, ContextC
     private List<DataAssociation> inMapping = new LinkedList<DataAssociation>();
     private List<DataAssociation> outMapping = new LinkedList<DataAssociation>();
 
-    private boolean independent = true;    
+    private boolean independent = true;
+    private SubProcessFactory subProcessFactory;
 
     public void setProcessId(final String processId) {
         this.processId = processId;
@@ -237,4 +241,12 @@ public class SubProcessNode extends StateBasedNode implements Mappable, ContextC
         return Boolean.parseBoolean(abortParent);
     }
 
+    public <T> void setSubProcessFactory(
+            SubProcessFactory<T> subProcessFactory) {
+        this.subProcessFactory = subProcessFactory;
+    }
+
+    public SubProcessFactory getSubProcessFactory() {
+        return subProcessFactory;
+    }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/CodegenNodeInstanceFactoryRegistry.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/CodegenNodeInstanceFactoryRegistry.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.workflow.instance.impl;
+
+import org.jbpm.workflow.core.node.SubProcessNode;
+import org.jbpm.workflow.instance.node.LambdaSubProcessNodeInstance;
+
+public class CodegenNodeInstanceFactoryRegistry extends NodeInstanceFactoryRegistry {
+
+    @Override
+    protected NodeInstanceFactory get(Class<?> clazz) {
+        if (SubProcessNode.class == clazz) {
+            return factory(LambdaSubProcessNodeInstance::new);
+        }
+        return super.get(clazz);
+    }
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceFactoryRegistry.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceFactoryRegistry.java
@@ -106,7 +106,7 @@ public class NodeInstanceFactoryRegistry {
         return null;
     }
 
-    private NodeInstanceFactory get(Class<?> clazz) {
+    protected NodeInstanceFactory get(Class<?> clazz) {
         // hard wired nodes:
         if (RuleSetNode.class == clazz) {
             return factory(RuleSetNodeInstance::new);
@@ -179,7 +179,7 @@ public class NodeInstanceFactoryRegistry {
         return this.registry.get(clazz);
     }
 
-    private NodeInstanceFactory factoryOnce(Supplier<NodeInstanceImpl> supplier) {
+    protected NodeInstanceFactory factoryOnce(Supplier<NodeInstanceImpl> supplier) {
         return (node, processInstance, nodeInstanceContainer) -> {
             NodeInstance result = ((org.jbpm.workflow.instance.NodeInstanceContainer)
                     nodeInstanceContainer).getFirstNodeInstance(node.getId());
@@ -191,7 +191,7 @@ public class NodeInstanceFactoryRegistry {
         };
     }
 
-    private NodeInstanceFactory factory(Supplier<NodeInstanceImpl> supplier) {
+    protected NodeInstanceFactory factory(Supplier<NodeInstanceImpl> supplier) {
         return (node, processInstance, nodeInstanceContainer) ->
                 createInstance(supplier.get(), node, processInstance, nodeInstanceContainer);
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/LambdaSubProcessNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/LambdaSubProcessNodeInstance.java
@@ -93,7 +93,7 @@ public class LambdaSubProcessNodeInstance extends StateBasedNodeInstance impleme
         SubProcessFactory subProcessFactory = getSubProcessNode().getSubProcessFactory();
         Object o = subProcessFactory.bind(context);
         org.kie.submarine.process.ProcessInstance<?> processInstance = subProcessFactory.createInstance(o);
-        subProcessFactory.unbind(context, o);
+        
 
 //            KieRuntime kruntime = ((ProcessInstance) getProcessInstance()).getKnowledgeRuntime();
 //            if (getSubProcessNode().getMetaData("MICollectionInput") != null) {
@@ -134,6 +134,8 @@ public class LambdaSubProcessNodeInstance extends StateBasedNodeInstance impleme
 
 
         processInstance.start();
+        
+        subProcessFactory.unbind(context, processInstance.variables());
     }
 
     private Map<String, Object> prepareParameters() {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/LambdaSubProcessNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/LambdaSubProcessNodeInstance.java
@@ -1,0 +1,398 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.workflow.instance.node;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.drools.core.common.InternalKnowledgeRuntime;
+import org.drools.core.spi.ProcessContext;
+import org.drools.core.util.MVELSafeHelper;
+import org.jbpm.process.core.Context;
+import org.jbpm.process.core.ContextContainer;
+import org.jbpm.process.core.context.exception.ExceptionScope;
+import org.jbpm.process.core.context.variable.VariableScope;
+import org.jbpm.process.core.impl.DataTransformerRegistry;
+import org.jbpm.process.instance.ContextInstance;
+import org.jbpm.process.instance.ContextInstanceContainer;
+import org.jbpm.process.instance.ProcessInstance;
+import org.jbpm.process.instance.context.exception.ExceptionScopeInstance;
+import org.jbpm.process.instance.context.variable.VariableScopeInstance;
+import org.jbpm.process.instance.impl.ContextInstanceFactory;
+import org.jbpm.process.instance.impl.ContextInstanceFactoryRegistry;
+import org.jbpm.process.instance.impl.util.VariableUtil;
+import org.jbpm.workflow.core.node.DataAssociation;
+import org.jbpm.workflow.core.node.SubProcessFactory;
+import org.jbpm.workflow.core.node.SubProcessNode;
+import org.jbpm.workflow.core.node.Transformation;
+import org.jbpm.workflow.instance.impl.NodeInstanceResolverFactory;
+import org.jbpm.workflow.instance.impl.VariableScopeResolverFactory;
+import org.jbpm.workflow.instance.impl.WorkflowProcessInstanceImpl;
+import org.kie.api.definition.process.Node;
+import org.kie.api.definition.process.Process;
+import org.kie.api.runtime.process.DataTransformer;
+import org.kie.api.runtime.process.EventListener;
+import org.kie.api.runtime.process.NodeInstance;
+import org.kie.internal.KieInternalServices;
+import org.kie.internal.process.CorrelationKey;
+import org.kie.internal.process.CorrelationKeyFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runtime counterpart of a SubFlow node.
+ * 
+ */
+public class LambdaSubProcessNodeInstance extends StateBasedNodeInstance implements EventListener, ContextInstanceContainer {
+
+    private static final long serialVersionUID = 510l;
+    private static final Logger logger = LoggerFactory.getLogger(LambdaSubProcessNodeInstance.class);
+
+    // NOTE: ContetxInstances are not persisted as current functionality (exception scope) does not require it
+    private Map<String, ContextInstance> contextInstances = new HashMap<String, ContextInstance>();
+    private Map<String, List<ContextInstance>> subContextInstances = new HashMap<String, List<ContextInstance>>();
+
+    private long processInstanceId;
+
+    protected SubProcessNode getSubProcessNode() {
+        return (SubProcessNode) getNode();
+    }
+
+    public void internalTrigger(final NodeInstance from, String type) {
+    	super.internalTrigger(from, type);
+    	// if node instance was cancelled, abort
+		if (getNodeInstanceContainer().getNodeInstance(getId()) == null) {
+			return;
+		}
+        if (!org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE.equals(type)) {
+            throw new IllegalArgumentException(
+                "A SubProcess node only accepts default incoming connections!");
+        }
+
+        String processId = getSubProcessNode().getProcessId();
+
+        ProcessContext context = new ProcessContext(getProcessInstance().getKnowledgeRuntime());
+        context.setNodeInstance(this);
+        SubProcessFactory subProcessFactory = getSubProcessNode().getSubProcessFactory();
+        Object o = subProcessFactory.bind(context);
+        org.kie.submarine.process.ProcessInstance<?> processInstance = subProcessFactory.createInstance(o);
+        subProcessFactory.unbind(context, o);
+
+//            KieRuntime kruntime = ((ProcessInstance) getProcessInstance()).getKnowledgeRuntime();
+//            if (getSubProcessNode().getMetaData("MICollectionInput") != null) {
+//                // remove foreach input variable to avoid problems when running in variable strict mode
+//                parameters.remove(getSubProcessNode().getMetaData("MICollectionInput"));
+//            }
+
+            if (((WorkflowProcessInstanceImpl)getProcessInstance()).getCorrelationKey() != null) {
+                // in case there is correlation key on parent instance pass it along to child so it can be easily correlated
+                // since correlation key must be unique for active instances it appends processId and timestamp
+                List<String> businessKeys = new ArrayList<String>();
+                businessKeys.add(((WorkflowProcessInstanceImpl)getProcessInstance()).getCorrelationKey());
+                businessKeys.add(processId);
+                businessKeys.add(String.valueOf(System.currentTimeMillis()));
+                CorrelationKeyFactory correlationKeyFactory = KieInternalServices.Factory.get().newCorrelationKeyFactory();
+                CorrelationKey subProcessCorrelationKey = correlationKeyFactory.newCorrelationKey(businessKeys);
+                throw new UnsupportedOperationException("correlation key is unsupported");
+//                processInstance = (ProcessInstance) ((CorrelationAwareProcessRuntime)kruntime).createProcessInstance(processId, subProcessCorrelationKey, parameters);
+            } else {
+//                processInstance = ( ProcessInstance ) kruntime.createProcessInstance(processId, parameters);
+            }
+//	    	this.processInstanceId = processInstance.getId();
+//	    	((ProcessInstanceImpl) processInstance).setMetaData("ParentProcessInstanceId", getProcessInstance().getId());
+//	    	((ProcessInstanceImpl) processInstance).setMetaData("ParentNodeInstanceId", getUniqueId());
+//	    	((ProcessInstanceImpl) processInstance).setMetaData("ParentNodeId", getSubProcessNode().getUniqueId());
+//	    	((ProcessInstanceImpl) processInstance).setParentProcessInstanceId(getProcessInstance().getId());
+//	    	((ProcessInstanceImpl) processInstance).setSignalCompletion(getSubProcessNode().isWaitForCompletion());
+//
+//	    	kruntime.startProcessInstance(processInstance.getId());
+//	    	if (!getSubProcessNode().isWaitForCompletion()) {
+//	    		triggerCompleted();
+//	    	} else if (processInstance.getState() == ProcessInstance.STATE_COMPLETED
+//	    	        || processInstance.getState() == ProcessInstance.STATE_ABORTED) {
+//	    	    processInstanceCompleted(processInstance);
+//	    	} else {
+//	    		addProcessListener();
+//	    	}
+
+
+        processInstance.start();
+    }
+
+    private Map<String, Object> prepareParameters() {
+        Map<String, Object> parameters = new HashMap<String, Object>();
+        for (Iterator<DataAssociation> iterator =  getSubProcessNode().getInAssociations().iterator(); iterator.hasNext(); ) {
+        	DataAssociation mapping = iterator.next();
+        	Object parameterValue = null;
+        	if (mapping.getTransformation() != null) {
+            	Transformation transformation = mapping.getTransformation();
+            	DataTransformer transformer = DataTransformerRegistry.get().find(transformation.getLanguage());
+            	if (transformer != null) {
+            		parameterValue = transformer.transform(transformation.getCompiledExpression(), getSourceParameters(mapping));
+
+            	}
+            } else {
+
+	            VariableScopeInstance variableScopeInstance = (VariableScopeInstance)
+	                resolveContextInstance(VariableScope.VARIABLE_SCOPE, mapping.getSources().get(0));
+	            if (variableScopeInstance != null) {
+	                parameterValue = variableScopeInstance.getVariable(mapping.getSources().get(0));
+	            } else {
+	            	try {
+	            		parameterValue = MVELSafeHelper.getEvaluator().eval(mapping.getSources().get(0), new NodeInstanceResolverFactory(this));
+	            	} catch (Throwable t) {
+	            	    parameterValue = VariableUtil.resolveVariable(mapping.getSources().get(0), this);
+	                    if (parameterValue != null) {
+	                        parameters.put(mapping.getTarget(), parameterValue);
+	                    } else {
+    	            	    logger.error("Could not find variable scope for variable {}", mapping.getSources().get(0));
+    	            	    logger.error("when trying to execute SubProcess node {}", getSubProcessNode().getName());
+    	            	    logger.error("Continuing without setting parameter.");
+	                    }
+	            	}
+	            }
+            }
+            if (parameterValue != null) {
+            	parameters.put(mapping.getTarget(),parameterValue);
+            }
+        }
+        return parameters;
+    }
+
+    private Process getProcess(String processId) {
+        return null;
+    }
+
+    public void cancel() {
+        super.cancel();
+        if (getSubProcessNode() == null || !getSubProcessNode().isIndependent()) {
+        	ProcessInstance processInstance = null;
+        	InternalKnowledgeRuntime kruntime = ((ProcessInstance) getProcessInstance()).getKnowledgeRuntime();
+
+    		processInstance = (ProcessInstance) kruntime.getProcessInstance(processInstanceId);
+
+
+            if (processInstance != null) {
+            	processInstance.setState(ProcessInstance.STATE_ABORTED);
+            }
+        }
+    }
+
+    public long getProcessInstanceId() {
+    	return processInstanceId;
+    }
+
+    public void internalSetProcessInstanceId(long processInstanceId) {
+    	this.processInstanceId = processInstanceId;
+    }
+
+    public void addEventListeners() {
+        super.addEventListeners();
+        addProcessListener();
+    }
+
+    private void addProcessListener() {
+    	getProcessInstance().addEventListener("processInstanceCompleted:" + processInstanceId, this, true);
+    }
+
+    public void removeEventListeners() {
+        super.removeEventListeners();
+        getProcessInstance().removeEventListener("processInstanceCompleted:" + processInstanceId, this, true);
+    }
+
+    @Override
+	public void signalEvent(String type, Object event) {
+		if (("processInstanceCompleted:" + processInstanceId).equals(type)) {
+			processInstanceCompleted((ProcessInstance) event);
+		} else {
+			super.signalEvent(type, event);
+		}
+	}
+
+    @Override
+    public String[] getEventTypes() {
+    	return new String[] { "processInstanceCompleted:" + processInstanceId };
+    }
+
+    public void processInstanceCompleted(ProcessInstance processInstance) {
+        removeEventListeners();
+        handleOutMappings(processInstance);
+        if (processInstance.getState() == ProcessInstance.STATE_ABORTED) {
+            String faultName = processInstance.getOutcome()==null?"":processInstance.getOutcome();
+            // handle exception as sub process failed with error code
+            ExceptionScopeInstance exceptionScopeInstance = (ExceptionScopeInstance)
+                    resolveContextInstance(ExceptionScope.EXCEPTION_SCOPE, faultName);
+            if (exceptionScopeInstance != null) {
+
+                exceptionScopeInstance.handleException(faultName, processInstance.getFaultData());
+                if (getSubProcessNode() != null && !getSubProcessNode().isIndependent() && getSubProcessNode().isAbortParent()){
+                    cancel();
+                }
+                return;
+            } else if (getSubProcessNode() != null && !getSubProcessNode().isIndependent() && getSubProcessNode().isAbortParent()){
+                ((ProcessInstance) getProcessInstance()).setState(ProcessInstance.STATE_ABORTED, faultName);
+                return;
+            }
+
+        }
+        // handle dynamic subprocess
+        if (getNode() == null) {
+            setMetaData("NodeType", "SubProcessNode");
+        }
+        // if there were no exception proceed normally
+        triggerCompleted();
+
+    }
+
+    private void handleOutMappings(ProcessInstance processInstance) {
+        VariableScopeInstance subProcessVariableScopeInstance = (VariableScopeInstance)
+	        processInstance.getContextInstance(VariableScope.VARIABLE_SCOPE);
+        SubProcessNode subProcessNode = getSubProcessNode();
+        if (subProcessNode != null) {
+		    for (Iterator<DataAssociation> iterator= subProcessNode.getOutAssociations().iterator(); iterator.hasNext(); ) {
+		    	DataAssociation mapping = iterator.next();
+		    	if (mapping.getTransformation() != null) {
+                	Transformation transformation = mapping.getTransformation();
+                	DataTransformer transformer = DataTransformerRegistry.get().find(transformation.getLanguage());
+                	if (transformer != null) {
+                		Object parameterValue = transformer.transform(transformation.getCompiledExpression(), subProcessVariableScopeInstance.getVariables());
+                		VariableScopeInstance variableScopeInstance = (VariableScopeInstance)
+                        resolveContextInstance(VariableScope.VARIABLE_SCOPE, mapping.getTarget());
+                        if (variableScopeInstance != null && parameterValue != null) {
+
+                            variableScopeInstance.setVariable(mapping.getTarget(), parameterValue);
+                        } else {
+                            logger.warn("Could not find variable scope for variable {}", mapping.getTarget());
+                            logger.warn("Continuing without setting variable.");
+                        }
+                	}
+                } else {
+			        VariableScopeInstance variableScopeInstance = (VariableScopeInstance)
+			            resolveContextInstance(VariableScope.VARIABLE_SCOPE, mapping.getTarget());
+			        if (variableScopeInstance != null) {
+			        	Object value = subProcessVariableScopeInstance.getVariable(mapping.getSources().get(0));
+			        	if (value == null) {
+			        		try {
+			            		value = MVELSafeHelper.getEvaluator().eval(mapping.getSources().get(0), new VariableScopeResolverFactory(subProcessVariableScopeInstance));
+			            	} catch (Throwable t) {
+			            		// do nothing
+			            	}
+			        	}
+			            variableScopeInstance.setVariable(mapping.getTarget(), value);
+			        } else {
+			            logger.error("Could not find variable scope for variable {}", mapping.getTarget());
+			            logger.error("when trying to complete SubProcess node {}", getSubProcessNode().getName());
+			            logger.error("Continuing without setting variable.");
+			        }
+                }
+		    }
+        } else {
+            // handle dynamic sub processes without data output mapping            
+            mapDynamicOutputData(subProcessVariableScopeInstance.getVariables());
+        }
+    }
+
+    public String getNodeName() {
+    	Node node = getNode();
+    	if (node == null) {
+    		return "[Dynamic] Sub Process";
+    	}
+    	return super.getNodeName();
+    }
+
+
+    @Override
+    public List<ContextInstance> getContextInstances(String contextId) {
+        return this.subContextInstances.get(contextId);
+    }
+
+    @Override
+    public void addContextInstance(String contextId, ContextInstance contextInstance) {
+        List<ContextInstance> list = this.subContextInstances.get(contextId);
+        if (list == null) {
+            list = new ArrayList<ContextInstance>();
+            this.subContextInstances.put(contextId, list);
+        }
+        list.add(contextInstance);
+    }
+
+    @Override
+    public void removeContextInstance(String contextId, ContextInstance contextInstance) {
+        List<ContextInstance> list = this.subContextInstances.get(contextId);
+        if (list != null) {
+            list.remove(contextInstance);
+        }
+    }
+
+    @Override
+    public ContextInstance getContextInstance(String contextId, long id) {
+        List<ContextInstance> contextInstances = subContextInstances.get(contextId);
+        if (contextInstances != null) {
+            for (ContextInstance contextInstance: contextInstances) {
+                if (contextInstance.getContextId() == id) {
+                    return contextInstance;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public ContextInstance getContextInstance(Context context) {
+        ContextInstanceFactory conf = ContextInstanceFactoryRegistry.INSTANCE.getContextInstanceFactory(context);
+        if (conf == null) {
+            throw new IllegalArgumentException("Illegal context type (registry not found): " + context.getClass());
+        }
+        ContextInstance contextInstance = (ContextInstance) conf.getContextInstance(context, this, (ProcessInstance) getProcessInstance());
+        if (contextInstance == null) {
+            throw new IllegalArgumentException("Illegal context type (instance not found): " + context.getClass());
+        }
+        return contextInstance;
+    }
+
+    @Override
+    public ContextContainer getContextContainer() {
+        return getSubProcessNode();
+    }
+
+    protected Map<String, Object> getSourceParameters(DataAssociation association) {
+    	Map<String, Object> parameters = new HashMap<String, Object>();
+    	for (String sourceParam : association.getSources()) {
+	    	Object parameterValue = null;
+	        VariableScopeInstance variableScopeInstance = (VariableScopeInstance)
+	        resolveContextInstance(VariableScope.VARIABLE_SCOPE, sourceParam);
+	        if (variableScopeInstance != null) {
+	            parameterValue = variableScopeInstance.getVariable(sourceParam);
+	        } else {
+	            try {
+	                parameterValue = MVELSafeHelper.getEvaluator().eval(sourceParam, new NodeInstanceResolverFactory(this));
+	            } catch (Throwable t) {
+	                logger.warn("Could not find variable scope for variable {}", sourceParam);
+	            }
+	        }
+	        if (parameterValue != null) {
+	        	parameters.put(association.getTarget(), parameterValue);
+	        }
+    	}
+
+    	return parameters;
+    }
+
+}

--- a/jbpm/jbpm-flow/src/main/java/org/kie/submarine/process/impl/AbstractProcess.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/submarine/process/impl/AbstractProcess.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine.process.impl;
+
+import java.util.Collections;
+
+import org.jbpm.process.instance.LightProcessRuntime;
+import org.jbpm.process.instance.LightProcessRuntimeContext;
+import org.jbpm.process.instance.LightProcessRuntimeServiceProvider;
+import org.jbpm.process.instance.ProcessRuntimeServiceProvider;
+import org.kie.api.runtime.process.ProcessRuntime;
+import org.kie.submarine.process.Process;
+import org.kie.submarine.process.ProcessConfig;
+import org.kie.submarine.process.Signal;
+
+public abstract class AbstractProcess<T> implements Process<T> {
+
+    private final MapProcessInstances<T> instances;
+
+    private final ProcessRuntimeServiceProvider services;
+
+    protected AbstractProcess(ProcessRuntimeServiceProvider services) {
+        this.services = services;
+        this.instances = new MapProcessInstances<>();
+    }
+
+    protected AbstractProcess() {
+        this(new LightProcessRuntimeServiceProvider());
+    }
+
+    protected AbstractProcess(ProcessConfig config) {
+        this(new ConfiguredProcessServices(config));
+    }
+
+    @Override
+    public final MapProcessInstances<T> instances() {
+        return instances;
+    }
+
+    @Override
+    public final <S> void send(Signal<S> signal) {
+        instances().values().forEach(pi -> pi.send(signal));
+    }
+
+    protected abstract org.kie.api.definition.process.Process legacyProcess();
+
+    protected ProcessRuntime createLegacyProcessRuntime() {
+        return new LightProcessRuntime(
+                new LightProcessRuntimeContext(Collections.singletonList(legacyProcess())),
+                services);
+    }
+}

--- a/jbpm/jbpm-flow/src/main/java/org/kie/submarine/process/impl/AbstractProcessInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/submarine/process/impl/AbstractProcessInstance.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine.process.impl;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.kie.api.runtime.process.ProcessRuntime;
+import org.kie.submarine.process.Process;
+import org.kie.submarine.process.ProcessInstance;
+import org.kie.submarine.process.Signal;
+
+public abstract class AbstractProcessInstance<T> implements ProcessInstance<T> {
+
+    private final T variables;
+    private final AbstractProcess<T> process;
+    private final ProcessRuntime rt;
+    private org.kie.api.runtime.process.ProcessInstance legacyProcessInstance;
+
+    public AbstractProcessInstance(AbstractProcess<T> process, T variables, ProcessRuntime rt) {
+        this.process = process;
+        this.rt = rt;
+        this.variables = variables;
+    }
+
+    public void start() {
+        Map<String, Object> map = bind(variables);
+        String id = process.legacyProcess().getId();
+        this.legacyProcessInstance =
+                rt.createProcessInstance(id, map);
+        long pid = legacyProcessInstance.getId();
+        process.instances().update(
+                pid, this);
+        this.rt.startProcessInstance(pid);
+        unbind(variables, map);
+    }
+
+    public void abort() {
+        if (legacyProcessInstance == null) return;
+        long pid = legacyProcessInstance.getId();
+        process.instances().remove(pid);
+        this.rt.abortProcessInstance(pid);
+    }
+
+    @Override
+    public <S> void send(Signal<S> signal) {
+        legacyProcessInstance.signalEvent(signal.channel(), signal.payload());
+    }
+
+    @Override
+    public Process<T> process() {
+        return process;
+    }
+
+    @Override
+    public T variables() {
+        return variables;
+    }
+
+    // this must be overridden at compile time
+    protected Map<String, Object> bind(T variables) {
+        HashMap<String, Object> vmap = new HashMap<>();
+        try {
+            for (Field f : variables.getClass().getDeclaredFields()) {
+                f.setAccessible(true);
+                Object v = null;
+                v = f.get(variables);
+                vmap.put(f.getName(), v);
+            }
+        } catch (IllegalAccessException e) {
+            throw new Error(e);
+        }
+        vmap.put("$v", variables);
+        return vmap;
+    }
+
+    protected void unbind(T variables, Map<String, Object> vmap) {
+        try {
+            for (Field f : variables.getClass().getDeclaredFields()) {
+                f.setAccessible(true);
+                f.set(variables, vmap.get(f.getName()));
+            }
+        } catch (IllegalAccessException e) {
+            throw new Error(e);
+        }
+        vmap.put("$v", variables);
+    }
+}

--- a/jbpm/jbpm-flow/src/main/java/org/kie/submarine/process/impl/AbstractProcessInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/submarine/process/impl/AbstractProcessInstance.java
@@ -40,18 +40,19 @@ public abstract class AbstractProcessInstance<T> implements ProcessInstance<T> {
     public void start() {
         Map<String, Object> map = bind(variables);
         String id = process.legacyProcess().getId();
-        this.legacyProcessInstance =
-                rt.createProcessInstance(id, map);
+        this.legacyProcessInstance = rt.createProcessInstance(id, map);
         long pid = legacyProcessInstance.getId();
-        process.instances().update(
-                pid, this);
-        this.rt.startProcessInstance(pid);
-        unbind(variables, map);
+        process.instances().update(pid, this);
+        org.kie.api.runtime.process.ProcessInstance pi = this.rt.startProcessInstance(pid);
+        unbind(variables, pi.getVariables());
     }
 
     public void abort() {
-        if (legacyProcessInstance == null) return;
+        if (legacyProcessInstance == null) {
+            return;
+        }
         long pid = legacyProcessInstance.getId();
+        unbind(variables, legacyProcessInstance.getVariables());
         process.instances().remove(pid);
         this.rt.abortProcessInstance(pid);
     }

--- a/jbpm/jbpm-flow/src/main/java/org/kie/submarine/process/impl/CachedWorkItemHandlerConfig.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/submarine/process/impl/CachedWorkItemHandlerConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine.process.impl;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import org.jbpm.process.instance.impl.demo.DoNothingWorkItemHandler;
+import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
+import org.kie.api.runtime.process.WorkItemHandler;
+import org.kie.submarine.process.WorkItemHandlerConfig;
+
+public class CachedWorkItemHandlerConfig implements WorkItemHandlerConfig {
+
+    private final Map<String, WorkItemHandler> workItemHandlers = new HashMap<>();
+
+    public CachedWorkItemHandlerConfig() {
+        register("Log", new DoNothingWorkItemHandler());
+        register("Human Task", new SystemOutWorkItemHandler());
+    }
+
+    protected CachedWorkItemHandlerConfig register(String name, WorkItemHandler handler) {
+        workItemHandlers.put(name, handler);
+        return this;
+    }
+
+    @Override
+    public WorkItemHandler forName(String name) {
+        WorkItemHandler workItemHandler = workItemHandlers.get(name);
+        if (workItemHandler == null) {
+            throw new NoSuchElementException(name);
+        } else {
+            return workItemHandler;
+        }
+    }
+
+    @Override
+    public Collection<String> names() {
+        return workItemHandlers.keySet();
+    }
+}

--- a/jbpm/jbpm-flow/src/main/java/org/kie/submarine/process/impl/ConfiguredProcessServices.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/submarine/process/impl/ConfiguredProcessServices.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine.process.impl;
+
+import org.jbpm.process.instance.AbstractProcessRuntimeServiceProvider;
+import org.kie.services.time.impl.JDKTimerService;
+import org.kie.submarine.process.ProcessConfig;
+
+public class ConfiguredProcessServices extends AbstractProcessRuntimeServiceProvider {
+
+    public ConfiguredProcessServices(ProcessConfig config) {
+        super(new JDKTimerService(),
+              config.workItemHandlers());
+    }
+}

--- a/jbpm/jbpm-flow/src/main/java/org/kie/submarine/process/impl/DefaultWorkItemHandlerConfig.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/submarine/process/impl/DefaultWorkItemHandlerConfig.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine.process.impl;
+
+import org.jbpm.process.instance.impl.demo.DoNothingWorkItemHandler;
+import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
+
+public class DefaultWorkItemHandlerConfig extends CachedWorkItemHandlerConfig {{
+    register("Log", new DoNothingWorkItemHandler());
+    register("Human Task", new SystemOutWorkItemHandler());
+}}

--- a/jbpm/jbpm-flow/src/main/java/org/kie/submarine/process/impl/MapProcessInstances.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/submarine/process/impl/MapProcessInstances.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine.process.impl;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Optional;
+
+import org.kie.submarine.process.ProcessInstance;
+import org.kie.submarine.process.ProcessInstances;
+
+class MapProcessInstances<T> implements ProcessInstances<T> {
+
+    private final HashMap<Long, ProcessInstance<T>> instances = new HashMap<>();
+
+    @Override
+    public Optional<? extends ProcessInstance<T>> findById(long id) {
+        return Optional.ofNullable(instances.get(id));
+    }
+
+    @Override
+    public Collection<? extends ProcessInstance<T>> values() {
+        return instances.values();
+    }
+
+    void update(long id, ProcessInstance<T> instance) {
+        instances.put(id, instance);
+    }
+
+    void remove(long id) {
+        instances.remove(id);
+    }
+}

--- a/jbpm/jbpm-flow/src/main/java/org/kie/submarine/process/impl/Sig.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/submarine/process/impl/Sig.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine.process.impl;
+
+import org.kie.submarine.process.Signal;
+
+public final class Sig<T> implements Signal<T> {
+
+    private final String channel;
+    private final T payload;
+
+    public static <T> org.kie.submarine.process.Signal<T> of(String channel, T payload) {
+        return new Sig<>(channel, payload);
+    }
+
+    protected Sig(String channel, T payload) {
+        this.channel = channel;
+        this.payload = payload;
+    }
+
+    @Override
+    public String channel() {
+        return channel;
+    }
+
+    public T payload() {
+        return payload;
+    }
+}
+

--- a/jbpm/jbpm-flow/src/main/java/org/kie/submarine/process/impl/StaticProcessConfig.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/submarine/process/impl/StaticProcessConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.submarine.process.impl;
+
+import org.kie.submarine.process.ProcessConfig;
+import org.kie.submarine.process.WorkItemHandlerConfig;
+
+public class StaticProcessConfig implements ProcessConfig {
+
+    private final WorkItemHandlerConfig workItemHandlerConfig;
+
+    public StaticProcessConfig(WorkItemHandlerConfig workItemHandlerConfig) {
+        this.workItemHandlerConfig = workItemHandlerConfig;
+    }
+
+    @Override
+    public WorkItemHandlerConfig workItemHandlers() {
+        return this.workItemHandlerConfig;
+    }
+}

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateProcessModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateProcessModelMojo.java
@@ -11,29 +11,22 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.kie.maven.plugin;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.github.javaparser.ast.expr.NormalAnnotationExpr;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -42,54 +35,24 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.drools.core.io.impl.FileSystemResource;
-import org.drools.core.runtime.process.InternalProcessRuntime;
 import org.drools.core.util.StringUtils;
 import org.drools.core.xml.SemanticModules;
 import org.jbpm.bpmn2.xml.BPMNDISemanticModule;
 import org.jbpm.bpmn2.xml.BPMNExtensionsSemanticModule;
 import org.jbpm.bpmn2.xml.BPMNSemanticModule;
 import org.jbpm.compiler.canonical.ModelMetaData;
-import org.jbpm.compiler.canonical.ProcessMetaData;
 import org.jbpm.compiler.canonical.ProcessToExecModelGenerator;
 import org.jbpm.compiler.xml.XmlProcessReader;
-import org.jbpm.workflow.instance.impl.WorkflowProcessInstanceImpl;
 import org.kie.api.definition.process.Process;
 import org.kie.api.definition.process.WorkflowProcess;
 import org.kie.api.io.Resource;
-import org.kie.api.runtime.process.ProcessInstance;
-import org.kie.api.runtime.process.WorkItemHandler;
+import org.kie.maven.plugin.process.ModelClassGenerator;
+import org.kie.maven.plugin.process.ModuleGenerator;
+import org.kie.maven.plugin.process.ProcessExecutableModelGenerator;
+import org.kie.maven.plugin.process.ProcessGenerator;
+import org.kie.maven.plugin.process.ProcessInstanceGenerator;
+import org.kie.maven.plugin.process.ResourceGenerator;
 import org.xml.sax.SAXException;
-
-import com.github.javaparser.JavaParser;
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.Modifier.Keyword;
-import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.expr.AssignExpr;
-import com.github.javaparser.ast.expr.AssignExpr.Operator;
-import com.github.javaparser.ast.expr.BinaryExpr;
-import com.github.javaparser.ast.expr.BooleanLiteralExpr;
-import com.github.javaparser.ast.expr.CastExpr;
-import com.github.javaparser.ast.expr.EnclosedExpr;
-import com.github.javaparser.ast.expr.FieldAccessExpr;
-import com.github.javaparser.ast.expr.LambdaExpr;
-import com.github.javaparser.ast.expr.MethodCallExpr;
-import com.github.javaparser.ast.expr.Name;
-import com.github.javaparser.ast.expr.NameExpr;
-import com.github.javaparser.ast.expr.NullLiteralExpr;
-import com.github.javaparser.ast.expr.ObjectCreationExpr;
-import com.github.javaparser.ast.expr.SimpleName;
-import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
-import com.github.javaparser.ast.expr.StringLiteralExpr;
-import com.github.javaparser.ast.expr.ThisExpr;
-import com.github.javaparser.ast.expr.VariableDeclarationExpr;
-import com.github.javaparser.ast.stmt.BlockStmt;
-import com.github.javaparser.ast.stmt.ExpressionStmt;
-import com.github.javaparser.ast.stmt.IfStmt;
-import com.github.javaparser.ast.stmt.ReturnStmt;
-import com.github.javaparser.ast.type.ClassOrInterfaceType;
-import com.github.javaparser.ast.type.UnknownType;
 
 @Mojo(name = "generateProcessModel",
         requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
@@ -97,17 +60,14 @@ import com.github.javaparser.ast.type.UnknownType;
         defaultPhase = LifecyclePhase.COMPILE)
 public class GenerateProcessModelMojo extends AbstractKieMojo {
 
-    private static final String RESOURCE_CLASS_SUFFIX = "Resource";
-    private static final String BOOTSTRAP_PACKAGE = "org.kie.bootstrap.process";
-    private static final String BOOTSTRAP_CLASS = BOOTSTRAP_PACKAGE + ".ProcessRuntimeProvider";
+    public static final String BOOTSTRAP_PACKAGE = "org.kie.bootstrap.process";
     private static final SemanticModules BPMN_SEMANTIC_MODULES = new SemanticModules();
+
     static {
         BPMN_SEMANTIC_MODULES.addSemanticModule(new BPMNSemanticModule());
         BPMN_SEMANTIC_MODULES.addSemanticModule(new BPMNExtensionsSemanticModule());
         BPMN_SEMANTIC_MODULES.addSemanticModule(new BPMNDISemanticModule());
     }
-    
-    private static final List<String> DEFAULT_HANDLERS = Arrays.asList("Log", "Human Task");
 
     @Parameter(required = true, defaultValue = "${project.basedir}/src")
     private File sourceDir;
@@ -127,6 +87,11 @@ public class GenerateProcessModelMojo extends AbstractKieMojo {
     @Parameter(property = "generateProcessModel", defaultValue = "yes")
     private String generateProcessModel;
 
+    @Parameter(property = "dependencyInjection", defaultValue = "true")
+    private boolean dependencyInjection;
+
+    private final String additionalCompilerPath = "/generated-sources/process/main/java";
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (BPMNModelMode.shouldGenerateBPMNModel(generateProcessModel)) {
@@ -135,81 +100,159 @@ public class GenerateProcessModelMojo extends AbstractKieMojo {
     }
 
     private void generateProcessModel() throws MojoExecutionException {
+        project.addCompileSourceRoot(
+                Paths.get(
+                        targetDirectory.getPath(),
+                        additionalCompilerPath).toString());
+
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
 
         try {
             setSystemProperties(properties);
 
-            final List<String> compiledClassNames = new ArrayList<>();
-            final Set<String> workItems = new HashSet<>();
             List<File> processFiles = getBPMNFiles();
             Map<String, String> labels = new HashMap<>();
 
             getLog().debug("Process Files to process: " + processFiles);
-            List<Process> processes = new ArrayList<>();
+            Map<String, WorkflowProcess> processes = parseProcesses(processFiles);
 
-            for (File bpmnFile : processFiles) {
-                getLog().info(bpmnFile.getName());
-                FileSystemResource r = new FileSystemResource(bpmnFile);
-                processes.addAll(parseProcessFile(r));
+            List<ProcessGenerator> ps = new ArrayList<>();
+            List<ProcessInstanceGenerator> pis = new ArrayList<>();
+            List<ProcessExecutableModelGenerator> processExecutableModelGenerators = new ArrayList<>();
+            List<ResourceGenerator> rgs = new ArrayList<>();
+            Map<String, ModelMetaData> processIdToModel = new HashMap<>();
+            Map<String, ModelClassGenerator> processIdToModelGenerator = new HashMap<>();
+
+            ModuleGenerator moduleSourceClass = new ModuleGenerator(project.getGroupId())
+                    .withCdi(dependencyInjection);
+
+            // first we generate all the data classes from variable declarations
+            for (WorkflowProcess workFlowProcess : processes.values()) {
+                ModelClassGenerator mcg = new ModelClassGenerator(workFlowProcess);
+                processIdToModelGenerator.put(workFlowProcess.getId(), mcg);
+                processIdToModel.put(workFlowProcess.getId(), mcg.generate());
             }
-            
-            final String additionalCompilerPath = "/generated-sources/process/main/java";
-            addNewCompileRoot(additionalCompilerPath);
-            List<String> publicProcesses = new ArrayList<>();
-            
-            for (Process process : processes) {
-                WorkflowProcess workFlowProcess = (WorkflowProcess) process;
 
-                ProcessMetaData processMetaData = ProcessToExecModelGenerator.INSTANCE.generate(workFlowProcess);
-                workItems.addAll(processMetaData.getWorkItems());
-                // create class with executable model for the process
-                String processClazzName = processMetaData.getProcessClassName();
-                final Path processFileNameRelative = transformPathToMavenPath(processClazzName, ".java");
+            // then we can instantiate the exec model generator
+            // with the data classes that we have already resolved
+            ProcessToExecModelGenerator execModelGenerator =
+                    new ProcessToExecModelGenerator(processIdToModel);
 
-                compiledClassNames.add(getCompiledClassName(processFileNameRelative));
+            // collect all process descriptors (exec model)
+            for (WorkflowProcess workFlowProcess : processes.values()) {
+                ProcessExecutableModelGenerator execModelGen =
+                        new ProcessExecutableModelGenerator(workFlowProcess, execModelGenerator);
+                execModelGen.generate();
+                processExecutableModelGenerators.add(execModelGen);
+            }
 
-                final Path processFileName = Paths.get(targetDirectory.getPath(), additionalCompilerPath, processFileNameRelative.toString());                
-                createSourceFile(processFileName, processMetaData.getGeneratedClassModel());
-                
-                if (WorkflowProcess.PUBLIC_VISIBILITY.equalsIgnoreCase(workFlowProcess.getVisibility())) {
-                
-                    // create model class for all variables                    
-                    ModelMetaData modelMetaData = ProcessToExecModelGenerator.INSTANCE.generateModel(workFlowProcess);
-                    
-                    final Path modelFileNameRelative = transformPathToMavenPath(  modelMetaData.getModelClassName(), ".java");
-                    final Path modelFileName = Paths.get(targetDirectory.getPath(), additionalCompilerPath, modelFileNameRelative.toString());
-                    createSourceFile(modelFileName, modelMetaData.getGeneratedClassModel());
-                    
-                
+            // generate Process, ProcessInstance classes and the REST resource
+            for (ProcessExecutableModelGenerator execModelGen : processExecutableModelGenerators) {
+                String classPrefix = StringUtils.capitalize(execModelGen.extractedProcessId());
+                WorkflowProcess workFlowProcess = execModelGen.process();
+                ModelClassGenerator modelClassGenerator =
+                        processIdToModelGenerator.get(execModelGen.getProcessId());
+
+                ProcessGenerator p = new ProcessGenerator(
+                        workFlowProcess,
+                        execModelGen,
+                        processes,
+                        classPrefix,
+                        modelClassGenerator.className(),
+                        moduleSourceClass.targetCanonicalName())
+                        .withCdi(dependencyInjection);
+
+                ProcessInstanceGenerator pi = new ProcessInstanceGenerator(
+                        workFlowProcess.getPackageName(),
+                        classPrefix,
+                        modelClassGenerator.generate());
+
+                // do not generate REST endpoint if the process is not "public"
+                if (execModelGen.isPublic()) {
                     // create REST resource class for process
-                    String resourceClazzName = StringUtils.capitalize(processMetaData.getExtractedProcessId()) + "Resource";
-                    String resourceClazz = generateResourceClass(workFlowProcess, processMetaData.getProcessId(), modelMetaData.getModelClassSimpleName(), modelMetaData.getModelClassName(), compiledClassNames);
-                    
-                    final Path resourceFileNameRelative = transformPathToMavenPath( project.getGroupId() + "." + resourceClazzName, ".java");
-                    final Path resourceFileName = Paths.get(targetDirectory.getPath(), additionalCompilerPath, resourceFileNameRelative.toString());
-                    createSourceFile(resourceFileName, resourceClazz);
-                    
-                    labels.put(LABEL_PREFIX + processMetaData.getExtractedProcessId(), Optional.ofNullable(workFlowProcess.getMetaData().get("Description")).map(d -> d.toString()).orElse("Executes " + process.getName()));
-                    publicProcesses.add(processMetaData.getExtractedProcessId());
+                    ResourceGenerator resourceGenerator = new ResourceGenerator(
+                            workFlowProcess,
+                            modelClassGenerator.className())
+                            .withCdi(dependencyInjection);
+
+                    rgs.add(resourceGenerator);
+                }
+
+                moduleSourceClass.addProcess(p);
+
+                ps.add(p);
+                pis.add(pi);
+            }
+
+            List<String> publicProcesses = new ArrayList<>();
+
+            for (ModelClassGenerator modelClassGenerator : processIdToModelGenerator.values()) {
+                ModelMetaData mmd = modelClassGenerator.generate();
+                Files.write(pathOf(modelClassGenerator.generatedFilePath()),
+                            mmd.getGeneratedClassModel().getBytes());
+            }
+
+            for (ResourceGenerator resourceGenerator : rgs) {
+                Files.write(pathOf(resourceGenerator.generatedFilePath()),
+                            resourceGenerator.generate().getBytes());
+            }
+
+            for (ProcessGenerator p : ps) {
+                Files.write(pathOf(p.generatedFilePath()), p.generate().getBytes());
+            }
+
+            for (ProcessInstanceGenerator pi : pis) {
+                Files.write(pathOf(pi.generatedFilePath()), pi.generate().getBytes());
+            }
+
+            String workItemHandlerConfigClass = "org.kie.submarine.project.WorkItemHandlerConfig";
+            Path p = Paths.get(sourceDir.getPath(),
+                               "main/java",
+                               workItemHandlerConfigClass.replace('.', '/') + ".java");
+            if (Files.exists(p)) {
+                moduleSourceClass.setWorkItemHandlerClass(workItemHandlerConfigClass);
+            }
+
+            Files.write(pathOf(moduleSourceClass.generatedFilePath()),
+                        moduleSourceClass.generate().getBytes());
+
+            getLog().info("Process Model successfully generated");
+
+            for (ProcessExecutableModelGenerator legacyProcessGenerator : processExecutableModelGenerators) {
+                if (legacyProcessGenerator.isPublic()) {
+                    publicProcesses.add(legacyProcessGenerator.extractedProcessId());
+                    labels.put(legacyProcessGenerator.label(), legacyProcessGenerator.description());
                 }
             }
-            if (!compiledClassNames.isEmpty()) {
-                String boostrapClass = generateProcessRuntimeBootstrap(compiledClassNames, workItems);
-                final Path bootstrapFileNameRelative = transformPathToMavenPath(BOOTSTRAP_CLASS, ".java");
-                final Path rbootstrapFileName = Paths.get(targetDirectory.getPath(), additionalCompilerPath, bootstrapFileNameRelative.toString());
-                createSourceFile(rbootstrapFileName, boostrapClass);
-            }
-            getLog().info("Process Model successfully generated");
-            labels.put(LABEL_PREFIX + "processes", publicProcesses.stream().collect(Collectors.joining(",")));
+
+            labels.put(LABEL_PREFIX + "processes",
+                       publicProcesses.stream().collect(Collectors.joining(",")));
             writeLabelsImageMetadata(targetDirectory.getPath(), labels);
         } catch (Exception e) {
             throw new MojoExecutionException("An error was caught during process generation", e);
         } finally {
             Thread.currentThread().setContextClassLoader(contextClassLoader);
         }
+    }
 
+    private Map<String, WorkflowProcess> parseProcesses(List<File> processFiles) throws IOException, MojoExecutionException {
+        Map<String, WorkflowProcess> processes = new HashMap<>();
 
+        for (File bpmnFile : processFiles) {
+            getLog().info(bpmnFile.getName());
+            FileSystemResource r = new FileSystemResource(bpmnFile);
+            Collection<? extends Process> ps = parseProcessFile(r);
+            for (Process p : ps) {
+                processes.put(p.getId(), (WorkflowProcess) p);
+            }
+        }
+        return processes;
+    }
+
+    private Path pathOf(String end) {
+        Path path = Paths.get(targetDirectory.getPath(), additionalCompilerPath, end);
+        path.getParent().toFile().mkdirs();
+        return path;
     }
 
     private Collection<? extends Process> parseProcessFile(Resource r) throws IOException, MojoExecutionException {
@@ -229,239 +272,5 @@ public class GenerateProcessModelMojo extends AbstractKieMojo {
                 .map(Path::toFile)
                 .collect(Collectors.toList());
     }
-
-    private void createSourceFile(Path newFile, String sourceContent) {
-        try {
-            Files.deleteIfExists(newFile);
-            Files.createDirectories(newFile.getParent());
-            Path newFilePath = Files.createFile(newFile);
-            Files.write(newFilePath, sourceContent.getBytes());
-            getLog().info("Generating file " + newFilePath);
-        } catch (IOException e) {
-            throw new RuntimeException("Unable to write file", e);
-        }
-    }
-
-    private String getCompiledClassName(Path fileNameRelative) {
-        return fileNameRelative.toString()
-                                .replace("/", ".")
-                                .replace(".java", "");
-    }
-
-    private Path transformPathToMavenPath(String generatedFile, String ext) {
-        Path fileName = Paths.get(generatedFile.replaceAll("\\.", "/") + ext);
-        Path originalFilePath = Paths.get("src/main/java");
-        final Path fileNameRelative;
-        if(fileName.startsWith(originalFilePath)) {
-            fileNameRelative = originalFilePath.relativize(fileName);
-        } else {
-            fileNameRelative = fileName;
-        }
-        return fileNameRelative;
-    }
-
-    private void addNewCompileRoot(String droolsModelCompilerPath) {
-        final String newCompileSourceRoot = targetDirectory.getPath() + droolsModelCompilerPath;
-        project.addCompileSourceRoot(newCompileSourceRoot);
-    }
-    
-    
-    public String generateResourceClass(WorkflowProcess process, String processId, String dataClazzName, String modelfqcn, List<String> compiledClassNames) {
-       
-        CompilationUnit clazz = JavaParser.parse(this.getClass().getResourceAsStream("/class-templates/RestResourceTemplate.java"));
-        clazz.setPackageDeclaration(process.getPackageName());
-        clazz.addImport(modelfqcn);
-        Optional<ClassOrInterfaceDeclaration> resourceClassOptional = clazz.findFirst(ClassOrInterfaceDeclaration.class, sl -> true);
-
-        if (resourceClassOptional.isPresent()) {
-            String extractedProcessId = ProcessToExecModelGenerator.INSTANCE.exctactProcessId(process.getId());
-            String documentation = (String) process.getMetaData().get("Documentation");
-            if (documentation == null) {
-                documentation = "Covers life cycle operation of " + extractedProcessId;
-            }
-
-            ClassOrInterfaceDeclaration resourceClass = resourceClassOptional.get();
-
-            resourceClass.setName(StringUtils.capitalize(extractedProcessId) + RESOURCE_CLASS_SUFFIX);
-            resourceClass.addAnnotation(new SingleMemberAnnotationExpr(new Name("Path"), new StringLiteralExpr("/" + extractedProcessId)))
-            .addAnnotation(new SingleMemberAnnotationExpr(new Name("Api"), new StringLiteralExpr(documentation)));
-
-            MethodCallExpr bootstrapMethod = new MethodCallExpr(new NameExpr(BOOTSTRAP_CLASS), "getProcessRuntime");
-            resourceClass.addFieldWithInitializer(InternalProcessRuntime.class, "processRuntime", bootstrapMethod, Keyword.PRIVATE);
-            resourceClass.addFieldWithInitializer(String.class, "processId", new StringLiteralExpr(processId), Keyword.PRIVATE);
-
-            ClassOrInterfaceType type = JavaParser.parseClassOrInterfaceType(dataClazzName);
-            ClassOrInterfaceType processInstanceType = JavaParser.parseClassOrInterfaceType(ProcessInstance.class.getSimpleName());
-            ClassOrInterfaceType workFlowInstanceType = JavaParser.parseClassOrInterfaceType(WorkflowProcessInstanceImpl.class.getSimpleName());
-            ClassOrInterfaceType optionalType = JavaParser.parseClassOrInterfaceType(Optional.class.getSimpleName());
-
-            // creates new resource
-            MethodDeclaration create = resourceClass.addMethod("createResource", Keyword.PUBLIC)
-            .setType(type)
-            .addAnnotation("POST")
-            .addAnnotation(new SingleMemberAnnotationExpr(new Name("Produces"), new NameExpr("MediaType.APPLICATION_JSON")))
-            .addAnnotation(new SingleMemberAnnotationExpr(new Name("Consumes"), new NameExpr("MediaType.APPLICATION_JSON")));
-            NormalAnnotationExpr createOperationExpression = new NormalAnnotationExpr(new Name("ApiOperation"), new NodeList<>());
-            createOperationExpression.addPair("value", "\"Creates new instance of " + extractedProcessId + "\"");
-            createOperationExpression.addPair("tags", "{\"" + dataClazzName + "\"}");
-            create = create.addAnnotation(createOperationExpression);
-
-            create.addParameter(type, "resource");
-            BlockStmt bodyCreate = create.createBody();
-
-            IfStmt nullResource = new IfStmt(new BinaryExpr(new NameExpr("resource"), new NullLiteralExpr(), com.github.javaparser.ast.expr.BinaryExpr.Operator.EQUALS)
-                                             , new ExpressionStmt(new AssignExpr(new NameExpr("resource"),
-                                                              new ObjectCreationExpr(null, type, NodeList.nodeList()), AssignExpr.Operator.ASSIGN)),
-                                             null);
-            bodyCreate.addStatement(nullResource);
-
-            MethodCallExpr startProcess = new MethodCallExpr(new FieldAccessExpr(new ThisExpr(), "processRuntime"), "startProcess");
-            startProcess.addArgument(new FieldAccessExpr(new ThisExpr(), "processId"));
-            startProcess.addArgument(new MethodCallExpr(new NameExpr("resource"), "toMap"));
-            VariableDeclarationExpr piField = new VariableDeclarationExpr(processInstanceType, "pi");
-            bodyCreate.addStatement(new AssignExpr(piField, startProcess, Operator.ASSIGN));
-
-            MethodCallExpr fromMap = new MethodCallExpr(new NameExpr(type.getName()), "fromMap");
-            fromMap.addArgument(new MethodCallExpr(new NameExpr("pi"), "getId"));
-            fromMap.addArgument(new MethodCallExpr(new EnclosedExpr(new CastExpr(workFlowInstanceType, new NameExpr("pi"))), "getVariables"));
-            bodyCreate.addStatement(new ReturnStmt(fromMap));
-
-            // get all resources
-            MethodCallExpr getInstances = new MethodCallExpr(new FieldAccessExpr(new ThisExpr(), "processRuntime"), "getProcessInstances");
-            MethodCallExpr streamInstances = new MethodCallExpr(getInstances, "stream");
-
-            BlockStmt filterBody = new BlockStmt();
-            MethodCallExpr getProcessId = new MethodCallExpr(new NameExpr("pi"), "getProcessId");
-            MethodCallExpr equlasByProcessId = new MethodCallExpr(getProcessId, "equals").addArgument(new FieldAccessExpr(new ThisExpr(), "processId"));
-            filterBody.addStatement(new ReturnStmt(equlasByProcessId));
-            LambdaExpr filterLambda = new LambdaExpr(
-                    new com.github.javaparser.ast.body.Parameter(new UnknownType(), "pi"),
-                    filterBody
-            );
-            MethodCallExpr filterInstances = new MethodCallExpr(streamInstances, "filter").addArgument(filterLambda);
-
-            BlockStmt mapBody = new BlockStmt();
-            mapBody.addStatement(new ReturnStmt(fromMap));
-            LambdaExpr mapLambda = new LambdaExpr(
-                    new com.github.javaparser.ast.body.Parameter(new UnknownType(), "pi"),
-                    mapBody
-            );
-
-            NormalAnnotationExpr collectOperationExpression = new NormalAnnotationExpr(new Name("ApiOperation"), new NodeList<>());
-            collectOperationExpression.addPair("value", "\"Returns a list of " + extractedProcessId + "\"");
-            collectOperationExpression.addPair("tags", "{\"" + dataClazzName + "\"}");
-            MethodCallExpr mapInstances = new MethodCallExpr(filterInstances, "map").addArgument(mapLambda);
-            MethodCallExpr collectInstances = new MethodCallExpr(mapInstances, "collect").addArgument(new MethodCallExpr(new NameExpr(JavaParser.parseClassOrInterfaceType(Collectors.class.getSimpleName()).getName()), "toList"));
-            resourceClass.addMethod("getResources", Keyword.PUBLIC).setType("List<" + dataClazzName + ">")
-            .addAnnotation("GET")
-            .addAnnotation(new SingleMemberAnnotationExpr(new Name("Produces"), new NameExpr("MediaType.APPLICATION_JSON")))
-            .addAnnotation(collectOperationExpression)
-            .createBody().addStatement(new ReturnStmt(collectInstances));
-
-            // get given resource            
-            MethodDeclaration get = resourceClass.addMethod("getResource", Keyword.PUBLIC).setType(dataClazzName)
-            .addAnnotation("GET")
-            .addAnnotation(new SingleMemberAnnotationExpr(new Name("Path"), new StringLiteralExpr("/{id}")))
-            .addAnnotation(new SingleMemberAnnotationExpr(new Name("Produces"), new NameExpr("MediaType.APPLICATION_JSON")));
-            NormalAnnotationExpr getOperationExpression = new NormalAnnotationExpr(new Name("ApiOperation"), new NodeList<>());
-            getOperationExpression.addPair("value", "\"Returns information about specified " + extractedProcessId + "\"") ;
-            getOperationExpression.addPair("tags", "{\"" + dataClazzName + "\"}");
-            get = get.addAnnotation(getOperationExpression);
-
-            MethodCallExpr getInstance = new MethodCallExpr(new FieldAccessExpr(new ThisExpr(), "processRuntime"), "getProcessInstance").addArgument(new NameExpr("id")).addArgument(new BooleanLiteralExpr(true));
-            MethodCallExpr ofNullable = new MethodCallExpr(new NameExpr(optionalType.getName()), "ofNullable").addArgument(getInstance);
-            MethodCallExpr mapInstance = new MethodCallExpr(ofNullable, "map").addArgument(mapLambda);
-            MethodCallExpr notPresent = new MethodCallExpr(mapInstance, "orElse").addArgument(new NullLiteralExpr());
-
-            get.addAndGetParameter(Long.class, "id").addAnnotation(new SingleMemberAnnotationExpr(new Name("PathParam"), new StringLiteralExpr("id")));
-            get.createBody().addStatement(new ReturnStmt(notPresent));
-
-            // delete given resource
-            MethodDeclaration delete = resourceClass.addMethod("deleteResource", Keyword.PUBLIC).setType(dataClazzName)
-            .addAnnotation("DELETE")
-            .addAnnotation(new SingleMemberAnnotationExpr(new Name("Path"), new StringLiteralExpr("/{id}")))
-            .addAnnotation(new SingleMemberAnnotationExpr(new Name("Produces"), new NameExpr("MediaType.APPLICATION_JSON")));
-            NormalAnnotationExpr deleteOperationExpression = new NormalAnnotationExpr(new Name("ApiOperation"), new NodeList<>());
-            deleteOperationExpression.addPair("value", "\"Cancels specified " + extractedProcessId + "\"");
-            deleteOperationExpression.addPair("tags", "{\"" + dataClazzName + "\"}");
-            delete = delete.addAnnotation(deleteOperationExpression);
-
-            delete.addAndGetParameter(Long.class, "id").addAnnotation(new SingleMemberAnnotationExpr(new Name("PathParam"), new StringLiteralExpr("id")));
-            BlockStmt deleteBody = delete.createBody();
-            VariableDeclarationExpr itemField = new VariableDeclarationExpr(type, "item");
-            deleteBody.addStatement(new AssignExpr(itemField, notPresent, Operator.ASSIGN));
-            deleteBody.addStatement(new MethodCallExpr(new FieldAccessExpr(new ThisExpr(), "processRuntime"), "abortProcessInstance").addArgument(new NameExpr("id")));
-            deleteBody.addStatement(new ReturnStmt(new NameExpr("item")));
-
-        }
-        return clazz.toString();
-    }
-
-    protected String generateProcessRuntimeBootstrap(List<String> compiledClassNames, Set<String> workItems) {
-        CompilationUnit clazz = JavaParser.parse(this.getClass().getResourceAsStream("/class-templates/ProcessRuntimeTemplate.java"));
-        clazz.setPackageDeclaration(BOOTSTRAP_PACKAGE);
-        clazz.addImport(ArrayList.class);
-        Optional<ClassOrInterfaceDeclaration> resourceClassOptional = clazz.findFirst(ClassOrInterfaceDeclaration.class, sl -> true);
-
-        if (resourceClassOptional.isPresent()) {
-
-            ClassOrInterfaceDeclaration resourceClass = resourceClassOptional.get();
-
-            // set processes found
-            MethodDeclaration getProcessesMethod = resourceClass.findFirst(MethodDeclaration.class, md -> md.getNameAsString().equals("getProcesses")).get();
-            BlockStmt body = new BlockStmt();
-
-            ClassOrInterfaceType listType = new ClassOrInterfaceType(null, new SimpleName(List.class.getSimpleName()), NodeList.nodeList(new ClassOrInterfaceType(null, Process.class.getSimpleName())));
-            VariableDeclarationExpr processesField = new VariableDeclarationExpr(listType, "processes");
-
-            body.addStatement(new AssignExpr(processesField, new ObjectCreationExpr(null, new ClassOrInterfaceType(null, ArrayList.class.getSimpleName()), NodeList.nodeList()), AssignExpr.Operator.ASSIGN));
-
-            for (String processClass : compiledClassNames) {
-                MethodCallExpr addProcess = new MethodCallExpr(new NameExpr("processes"), "add").addArgument(new MethodCallExpr(new NameExpr(processClass), "process"));
-                body.addStatement(addProcess);
-            }
-
-            body.addStatement(new ReturnStmt(new NameExpr("processes")));
-            getProcessesMethod.setBody(body);
-            
-            
-            // set work item handlers if found
-            workItems.removeAll(DEFAULT_HANDLERS);
-            if (!workItems.isEmpty()) {
-                Properties handlers = new Properties();
-                
-                try (FileInputStream in = new FileInputStream(new File(projectDir, "src/main/resources/workitem-handlers.properties"))){
-                    
-                    handlers.load(in);
-                } catch (Exception e) {
-                    getLog().info("Work item handlers config file was not found");
-                }
-            
-            
-                MethodDeclaration getHandlersMethod = resourceClass.findFirst(MethodDeclaration.class, md -> md.getNameAsString().equals("getWorkItemHandlers")).get();
-                BlockStmt hanldersBody = new BlockStmt();
-    
-                ClassOrInterfaceType handlersListType = new ClassOrInterfaceType(null, new SimpleName(List.class.getSimpleName()), NodeList.nodeList(new ClassOrInterfaceType(null, WorkItemHandler.class.getSimpleName())));
-                VariableDeclarationExpr handlersField = new VariableDeclarationExpr(handlersListType, "handlers");
-    
-                hanldersBody.addStatement(new AssignExpr(handlersField, new ObjectCreationExpr(null, new ClassOrInterfaceType(null, ArrayList.class.getSimpleName()), NodeList.nodeList()), AssignExpr.Operator.ASSIGN));
-    
-                for (String workItem : workItems) {
-                    String handlerClass = handlers.getProperty(workItem);
-                    if (handlerClass == null) {
-                        throw new IllegalArgumentException("Cannot find work work item handler for " + workItem);
-                    }
-                    MethodCallExpr addHandler = new MethodCallExpr(new NameExpr("handlers"), "add").addArgument(new ObjectCreationExpr(null, new ClassOrInterfaceType(null, handlerClass), NodeList.nodeList()));
-                    hanldersBody.addStatement(addHandler);
-                }
-    
-                hanldersBody.addStatement(new ReturnStmt(new NameExpr("handlers")));
-                getHandlersMethod.setBody(hanldersBody);
-            }
-        }
-
-        return clazz.toString();
-    }
-
 }
 

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateProcessModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateProcessModelMojo.java
@@ -111,6 +111,9 @@ public class GenerateProcessModelMojo extends AbstractKieMojo {
             setSystemProperties(properties);
 
             List<File> processFiles = getBPMNFiles();
+            if (processFiles.isEmpty()) {
+                return;
+            }
             Map<String, String> labels = new HashMap<>();
 
             getLog().debug("Process Files to process: " + processFiles);
@@ -205,7 +208,7 @@ public class GenerateProcessModelMojo extends AbstractKieMojo {
                 Files.write(pathOf(pi.generatedFilePath()), pi.generate().getBytes());
             }
 
-            String workItemHandlerConfigClass = "org.kie.submarine.project.WorkItemHandlerConfig";
+            String workItemHandlerConfigClass = project.getGroupId() + ".WorkItemHandlerConfig";
             Path p = Paths.get(sourceDir.getPath(),
                                "main/java",
                                workItemHandlerConfigClass.replace('.', '/') + ".java");

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/process/ModelClassGenerator.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/process/ModelClassGenerator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.maven.plugin.process;
+
+import org.drools.core.util.StringUtils;
+import org.jbpm.compiler.canonical.ModelMetaData;
+import org.jbpm.compiler.canonical.ProcessToExecModelGenerator;
+import org.kie.api.definition.process.WorkflowProcess;
+
+public class ModelClassGenerator {
+
+    private final WorkflowProcess workFlowProcess;
+    private String modelFileName;
+    private ModelMetaData modelMetaData;
+    private String modelClassName;
+
+    public ModelClassGenerator(WorkflowProcess workFlowProcess) {
+        String pid = workFlowProcess.getId();
+        String name = ProcessToExecModelGenerator.extractProcessId(pid);
+        this.modelClassName = workFlowProcess.getPackageName() + "." +
+                StringUtils.capitalize(name) + "Model";
+
+        this.workFlowProcess = workFlowProcess;
+    }
+
+    public ModelMetaData generate() {
+        // create model class for all variables
+        modelMetaData = ProcessToExecModelGenerator.INSTANCE.generateModel(workFlowProcess);
+        modelFileName = modelMetaData.getModelClassName().replace('.', '/') + ".java";
+        return modelMetaData;
+    }
+
+    public String generatedFilePath() {
+        return modelFileName;
+    }
+
+    public String simpleName() {
+        return modelMetaData.getModelClassSimpleName();
+    }
+
+    public String className() {
+        return modelClassName;
+    }
+}

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/process/ModuleGenerator.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/process/ModuleGenerator.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.maven.plugin.process;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.ThisExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import org.kie.maven.plugin.process.config.WorkItemConfigGenerator;
+import org.kie.submarine.process.impl.DefaultWorkItemHandlerConfig;
+import org.kie.submarine.rules.RuleUnit;
+
+public class ModuleGenerator {
+
+    private static final String RESOURCE = "/class-templates/ModuleTemplate.java";
+    private final String packageName;
+    private final String sourceFilePath;
+    private final String completePath;
+    private final String targetCanonicalName;
+    private final List<ProcessGenerator> processes;
+    private final List<ProcessInstanceGenerator> processInstances;
+    private String targetTypeName;
+    private boolean hasCdi;
+    private String workItemConfigClass = DefaultWorkItemHandlerConfig.class.getCanonicalName();
+
+    public ModuleGenerator(String groupId) {
+        this.packageName = groupId;
+        this.targetTypeName = "Module";
+        this.targetCanonicalName = packageName + "." + targetTypeName;
+        this.sourceFilePath = targetCanonicalName.replace('.', '/') + ".java";
+        this.completePath = "src/main/java/" + sourceFilePath;
+        this.processes = new ArrayList<>();
+        this.processInstances = new ArrayList<>();
+    }
+
+    public String targetCanonicalName() {
+        return targetCanonicalName;
+    }
+
+    public String generatedFilePath() {
+        return sourceFilePath;
+    }
+
+    public void addProcess(ProcessGenerator rusc) {
+        processes.add(rusc);
+    }
+
+    public void addProcessInstance(ProcessInstanceGenerator ruisc) {
+        processInstances.add(ruisc);
+    }
+
+    public String generate() {
+        return compilationUnit().toString();
+    }
+
+    public CompilationUnit compilationUnit() {
+        CompilationUnit compilationUnit =
+                JavaParser.parse(this.getClass().getResourceAsStream(RESOURCE))
+                        .setPackageDeclaration(packageName);
+        ClassOrInterfaceDeclaration cls = compilationUnit.findFirst(ClassOrInterfaceDeclaration.class).get();
+        if (hasCdi) {
+            cls.addAnnotation("javax.inject.Singleton");
+        }
+
+        for (ProcessGenerator r : processes) {
+            cls.addMember(processFactoryMethod(r));
+        }
+
+        cls.findFirst(ObjectCreationExpr.class, p -> p.getType().getNameAsString().equals("$WorkItemHandlerConfig$"))
+                .ifPresent(o -> o.setType(workItemConfigClass));
+
+        return compilationUnit;
+    }
+
+    public static MethodDeclaration processFactoryMethod(ProcessGenerator r) {
+        return new MethodDeclaration()
+                .addModifier(Modifier.Keyword.PUBLIC)
+                .setName("create" + r.targetTypeName())
+                .setType(r.targetCanonicalName())
+                .setBody(new BlockStmt().addStatement(new ReturnStmt(
+                        new ObjectCreationExpr()
+                                .setType(r.targetCanonicalName())
+                                .addArgument(new ThisExpr()))));
+    }
+
+    public ModuleGenerator withCdi(boolean hasCdi) {
+        this.hasCdi = hasCdi;
+        return this;
+    }
+
+    public void setWorkItemHandlerClass(String className) {
+        this.workItemConfigClass = className;
+    }
+}

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/process/ProcessExecutableModelGenerator.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/process/ProcessExecutableModelGenerator.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.maven.plugin.process;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.jbpm.compiler.canonical.ProcessMetaData;
+import org.jbpm.compiler.canonical.ProcessToExecModelGenerator;
+import org.kie.api.definition.process.WorkflowProcess;
+
+public class ProcessExecutableModelGenerator {
+
+    protected final static String LABEL_PREFIX = "org.kie.";
+
+    private final WorkflowProcess workFlowProcess;
+    private final ProcessToExecModelGenerator execModelGenerator;
+    private String processFilePath;
+    private ProcessMetaData processMetaData;
+
+    public ProcessExecutableModelGenerator(WorkflowProcess workFlowProcess, ProcessToExecModelGenerator execModelGenerator) {
+        this.workFlowProcess = workFlowProcess;
+        this.execModelGenerator = execModelGenerator;
+    }
+
+    public boolean isPublic() {
+        return WorkflowProcess.PUBLIC_VISIBILITY.equalsIgnoreCase(workFlowProcess.getVisibility());
+    }
+
+    public ProcessMetaData generate() {
+        if (processMetaData != null) return processMetaData;
+        processMetaData = execModelGenerator.generate(workFlowProcess);
+
+        // this is ugly, but this class will be refactored
+        String processClazzName = processMetaData.getProcessClassName();
+        processFilePath = processClazzName.replace('.', '/') + ".java";
+        return processMetaData;
+    }
+
+    public String label() {
+        return LABEL_PREFIX + extractedProcessId();
+    }
+
+    public String description() {
+        return Optional.ofNullable(workFlowProcess.getMetaData().get("Description"))
+                .map(Object::toString).orElse("Executes " + workFlowProcess.getName());
+    }
+
+    public String className() {
+        if (processMetaData == null) generate();
+        return processMetaData.getProcessClassName();
+    }
+
+    public String generatedFilePath() {
+        return processFilePath;
+    }
+
+    private String getCompiledClassName(Path fileNameRelative) {
+        return fileNameRelative.toString()
+                .replace("/", ".")
+                .replace(".java", "");
+    }
+
+    public String extractedProcessId() {
+        return execModelGenerator.extractProcessId(workFlowProcess.getId());
+    }
+
+    public String getProcessId() {
+        return workFlowProcess.getId();
+    }
+
+    public WorkflowProcess process() {
+        return workFlowProcess;
+    }
+}

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/process/ProcessGenerator.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/process/ProcessGenerator.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.maven.plugin.process;
+
+import java.util.Map;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.Name;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.expr.ThisExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
+import org.kie.api.definition.process.Process;
+import org.kie.api.definition.process.WorkflowProcess;
+import org.kie.submarine.process.impl.AbstractProcess;
+
+import static com.github.javaparser.ast.NodeList.nodeList;
+
+public class ProcessGenerator {
+
+    private final String packageName;
+    private final WorkflowProcess process;
+    private final ProcessExecutableModelGenerator legacyProcessGenerator;
+    private final Map<String, WorkflowProcess> processMapping;
+    private final String typeName;
+    private final String modelTypeName;
+    private final String generatedFilePath;
+    private final String completePath;
+    private final String canonicalName;
+    private final String targetCanonicalName;
+    private final String moduleCanonicalName;
+    private String targetTypeName;
+    private boolean hasCdi = false;
+
+    public ProcessGenerator(
+            WorkflowProcess process,
+            ProcessExecutableModelGenerator legacyProcessGenerator,
+            Map<String, WorkflowProcess> processMapping,
+            String typeName,
+            String modelTypeName,
+            String moduleCanonicalName) {
+
+        this.moduleCanonicalName = moduleCanonicalName;
+
+        this.packageName = process.getPackageName();
+        this.process = process;
+        this.legacyProcessGenerator = legacyProcessGenerator;
+        this.processMapping = processMapping;
+        this.typeName = typeName;
+        this.modelTypeName = modelTypeName;
+        this.canonicalName = packageName + "." + typeName;
+        this.targetTypeName = typeName + "Process";
+        this.targetCanonicalName = packageName + "." + targetTypeName;
+        this.generatedFilePath = targetCanonicalName.replace('.', '/') + ".java";
+        this.completePath = "src/main/java/" + generatedFilePath;
+    }
+
+    public String targetCanonicalName() {
+        return targetCanonicalName;
+    }
+
+    public String targetTypeName() {
+        return targetTypeName;
+    }
+
+    public void write(MemoryFileSystem srcMfs) {
+        srcMfs.write(completePath, generate().getBytes());
+    }
+
+    public String generate() {
+        return compilationUnit().toString();
+    }
+
+    public CompilationUnit compilationUnit() {
+        CompilationUnit compilationUnit = new CompilationUnit(packageName);
+        compilationUnit.addImport("org.jbpm.process.core.datatype.impl.type.ObjectDataType");
+        compilationUnit.addImport("org.jbpm.ruleflow.core.RuleFlowProcessFactory");
+        compilationUnit.getTypes().add(classDeclaration());
+        return compilationUnit;
+    }
+
+    private MethodDeclaration createInstanceMethod(String processInstanceFQCN) {
+        MethodDeclaration methodDeclaration = new MethodDeclaration();
+
+        ReturnStmt returnStmt = new ReturnStmt(
+                new ObjectCreationExpr()
+                        .setType(processInstanceFQCN)
+                        .setArguments(nodeList(
+                                new ThisExpr(),
+                                new NameExpr("value"),
+                                createProcessRuntime())));
+
+        methodDeclaration.setName("createInstance")
+                .addModifier(Modifier.Keyword.PUBLIC)
+                .addParameter(modelTypeName, "value")
+                .setType(processInstanceFQCN)
+                .setBody(new BlockStmt()
+                                 .addStatement(returnStmt));
+        return methodDeclaration;
+    }
+
+    private MethodDeclaration legacyProcess() {
+        MethodDeclaration legacyProcess = legacyProcessGenerator.generate()
+                .getGeneratedClassModel()
+                .findFirst(MethodDeclaration.class).get()
+                .setModifiers(Modifier.Keyword.PROTECTED)
+                .setType(Process.class.getCanonicalName())
+                .setName("legacyProcess");
+        return legacyProcess;
+    }
+
+    private MethodCallExpr createProcessRuntime() {
+        return new MethodCallExpr(
+                new ThisExpr(),
+                "createLegacyProcessRuntime");
+    }
+
+    public static ClassOrInterfaceType processType(String canonicalName) {
+        return new ClassOrInterfaceType(null, canonicalName + "Process");
+    }
+
+    public static ClassOrInterfaceType abstractProcessType(String canonicalName) {
+        return new ClassOrInterfaceType(null, AbstractProcess.class.getCanonicalName())
+                .setTypeArguments(new ClassOrInterfaceType(null, canonicalName));
+    }
+
+    public ClassOrInterfaceDeclaration classDeclaration() {
+        ClassOrInterfaceDeclaration cls = new ClassOrInterfaceDeclaration()
+                .setName(targetTypeName)
+                .setModifiers(Modifier.Keyword.PUBLIC);
+
+        if (hasCdi) {
+            cls.addAnnotation("javax.inject.Singleton")
+                    .addAnnotation(new SingleMemberAnnotationExpr(
+                            new Name("javax.inject.Named"),
+                            new StringLiteralExpr(process.getId())));
+        }
+
+        String processInstanceFQCN = ProcessInstanceGenerator.qualifiedName(packageName, typeName);
+
+        FieldDeclaration fieldDeclaration = new FieldDeclaration()
+                .addVariable(new VariableDeclarator(new ClassOrInterfaceType(null, moduleCanonicalName), "module"));
+
+        ConstructorDeclaration constructorDeclaration = new ConstructorDeclaration()
+                .setName(targetTypeName)
+                .addModifier(Modifier.Keyword.PUBLIC)
+                .addParameter(moduleCanonicalName, "module")
+                .setBody(new BlockStmt()
+                                 // super(module.config().process())
+                                 .addStatement(new MethodCallExpr(null, "super")
+                                              .addArgument(
+                                                      new MethodCallExpr(
+                                                              new MethodCallExpr(new NameExpr("module"), "config"),
+                                                              "process")))
+                                 .addStatement(
+                                         new AssignExpr(new FieldAccessExpr(new ThisExpr(), "module"), new NameExpr("module"), AssignExpr.Operator.ASSIGN)));
+        ConstructorDeclaration emptyConstructorDeclaration = new ConstructorDeclaration()
+                .setName(targetTypeName)
+                .addModifier(Modifier.Keyword.PUBLIC)
+                .setBody(new BlockStmt()
+                                 .addStatement(
+                                         new MethodCallExpr(null, "this").addArgument(new ObjectCreationExpr().setType(moduleCanonicalName))));
+
+        MethodDeclaration methodDeclaration = createInstanceMethod(processInstanceFQCN);
+        cls.addExtendedType(abstractProcessType(modelTypeName))
+                .addMember(fieldDeclaration)
+                .addMember(emptyConstructorDeclaration)
+                .addMember(constructorDeclaration)
+                .addMember(methodDeclaration)
+                .addMember(legacyProcess());
+        return cls;
+    }
+
+    public String generatedFilePath() {
+        return generatedFilePath;
+    }
+
+    public boolean isPublic() {
+        return WorkflowProcess.PUBLIC_VISIBILITY.equalsIgnoreCase(process.getVisibility());
+    }
+
+    public ProcessGenerator withCdi(boolean dependencyInjection) {
+        this.hasCdi = dependencyInjection;
+        return this;
+    }
+}

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/process/ProcessGenerator.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/process/ProcessGenerator.java
@@ -102,6 +102,7 @@ public class ProcessGenerator {
         CompilationUnit compilationUnit = new CompilationUnit(packageName);
         compilationUnit.addImport("org.jbpm.process.core.datatype.impl.type.ObjectDataType");
         compilationUnit.addImport("org.jbpm.ruleflow.core.RuleFlowProcessFactory");
+        compilationUnit.addImport("org.drools.core.util.KieFunctions");
         compilationUnit.getTypes().add(classDeclaration());
         return compilationUnit;
     }

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/process/ProcessInstanceGenerator.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/process/ProcessInstanceGenerator.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.maven.plugin.process;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.VoidType;
+import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
+import org.jbpm.compiler.canonical.ModelMetaData;
+import org.kie.api.runtime.process.ProcessRuntime;
+import org.kie.submarine.process.impl.AbstractProcessInstance;
+
+public class ProcessInstanceGenerator {
+
+    private final String packageName;
+    private final String typeName;
+    private final ModelMetaData model;
+    private final String canonicalName;
+    private final String targetTypeName;
+    private final String targetCanonicalName;
+    private final String generatedFilePath;
+    private final String completePath;
+
+    public static String qualifiedName(String packageName, String typeName) {
+        return packageName + "." + typeName + "ProcessInstance";
+    }
+
+    public ProcessInstanceGenerator(String packageName, String typeName, ModelMetaData model) {
+        this.packageName = packageName;
+        this.typeName = typeName;
+        this.model = model;
+        this.canonicalName = packageName + "." + typeName;
+        this.targetTypeName = typeName + "ProcessInstance";
+        this.targetCanonicalName = packageName + "." + targetTypeName;
+        this.generatedFilePath = targetCanonicalName.replace('.', '/') + ".java";
+        this.completePath = "src/main/java/" + generatedFilePath;
+    }
+
+    public void write(MemoryFileSystem srcMfs) {
+        srcMfs.write(completePath, generate().getBytes());
+    }
+
+    public String generate() {
+        return compilationUnit().toString();
+    }
+
+    public CompilationUnit compilationUnit() {
+        CompilationUnit compilationUnit = new CompilationUnit(packageName);
+        compilationUnit.getTypes().add(classDeclaration());
+        return compilationUnit;
+    }
+
+    public ClassOrInterfaceDeclaration classDeclaration() {
+        ClassOrInterfaceDeclaration classDecl = new ClassOrInterfaceDeclaration()
+                .setName(targetTypeName)
+                .addModifier(Modifier.Keyword.PUBLIC);
+        classDecl
+                .addExtendedType(
+                        new ClassOrInterfaceType(null, AbstractProcessInstance.class.getCanonicalName())
+                                .setTypeArguments(new ClassOrInterfaceType(null, model.getModelClassSimpleName())))
+                .addMember(constructorDecl())
+                .addMember(bind())
+                .addMember(unbind());
+
+        return classDecl;
+    }
+
+    private MethodDeclaration bind() {
+        String modelName = model.getModelClassSimpleName();
+        BlockStmt body = new BlockStmt()
+                .addStatement(new ReturnStmt(model.toMap("variables")));
+        return new MethodDeclaration()
+                .setModifiers(Modifier.Keyword.PROTECTED)
+                .setName("bind")
+                .addParameter(modelName, "variables")
+                .setType(new ClassOrInterfaceType()
+                                 .setName("java.util.Map")
+                                 .setTypeArguments(new ClassOrInterfaceType().setName("String"),
+                                                   new ClassOrInterfaceType().setName("Object")))
+                .setBody(body);
+
+    }
+
+    private MethodDeclaration unbind() {
+        String modelName = model.getModelClassSimpleName();
+        BlockStmt body = new BlockStmt()
+                .addStatement(model.fromMap("variables", "vmap"));
+
+        return new MethodDeclaration()
+                .setModifiers(Modifier.Keyword.PROTECTED)
+                .setName("unbind")
+                .setType(new VoidType())
+                .addParameter(modelName, "variables")
+                .addParameter(new ClassOrInterfaceType()
+                                      .setName("java.util.Map")
+                                      .setTypeArguments(new ClassOrInterfaceType().setName("String"),
+                                                        new ClassOrInterfaceType().setName("Object")),
+                              "vmap")
+                .setBody(body);
+    }
+
+    private ConstructorDeclaration constructorDecl() {
+        return new ConstructorDeclaration()
+                .setName(targetTypeName)
+                .addModifier(Modifier.Keyword.PUBLIC)
+                .addParameter(ProcessGenerator.processType(canonicalName), "process")
+                .addParameter(model.getModelClassSimpleName(), "value")
+                .addParameter(ProcessRuntime.class.getCanonicalName(), "processRuntime")
+                .setBody(new BlockStmt().addStatement(new MethodCallExpr(
+                        "super",
+                        new NameExpr("process"),
+                        new NameExpr("value"),
+                        new NameExpr("processRuntime"))));
+    }
+
+    public String targetTypeName() {
+        return targetTypeName;
+    }
+
+    public String generatedFilePath() {
+        return generatedFilePath;
+    }
+}

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/process/ProcessRuntimeBootstrapGenerator.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/process/ProcessRuntimeBootstrapGenerator.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.maven.plugin.process;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import org.kie.api.definition.process.Process;
+import org.kie.api.runtime.process.WorkItemHandler;
+
+import static org.kie.maven.plugin.GenerateProcessModelMojo.BOOTSTRAP_PACKAGE;
+
+public class ProcessRuntimeBootstrapGenerator {
+
+    private static final List<String> DEFAULT_HANDLERS = Arrays.asList("Log", "Human Task");
+
+    private final List<String> compiledClassNames;
+    private static final String BOOTSTRAP_CLASS = BOOTSTRAP_PACKAGE + ".ProcessRuntimeProvider";
+    private final String generatedFilePath;
+    private final Map<String, String> workItemHandlers;
+
+    public ProcessRuntimeBootstrapGenerator(List<ProcessExecutableModelGenerator> legacyProcesses, Map<String, String> workItemHandlers) {
+        this.workItemHandlers = workItemHandlers;
+        this.generatedFilePath = BOOTSTRAP_CLASS.replace('.', '/') + ".java";
+        this.compiledClassNames =
+                legacyProcesses.stream()
+                        .map(ProcessExecutableModelGenerator::className)
+                        .collect(Collectors.toList());
+    }
+
+    public String generatedFilePath() {
+        return generatedFilePath;
+    }
+
+    public String generate() {
+        CompilationUnit clazz = JavaParser.parse(this.getClass().getResourceAsStream("/class-templates/ProcessRuntimeTemplate.java"));
+        clazz.setPackageDeclaration(BOOTSTRAP_PACKAGE);
+        clazz.addImport(ArrayList.class);
+        Optional<ClassOrInterfaceDeclaration> resourceClassOptional = clazz.findFirst(ClassOrInterfaceDeclaration.class, sl -> true);
+
+        if (resourceClassOptional.isPresent()) {
+
+            ClassOrInterfaceDeclaration resourceClass = resourceClassOptional.get();
+
+            MethodDeclaration getProcessesMethod = resourceClass.findFirst(MethodDeclaration.class, md -> md.getNameAsString().equals("getProcesses")).get();
+            BlockStmt body = new BlockStmt();
+
+            ClassOrInterfaceType listType = new ClassOrInterfaceType(null, new SimpleName(List.class.getSimpleName()), NodeList.nodeList(new ClassOrInterfaceType(null, Process.class.getSimpleName())));
+            VariableDeclarationExpr processesField = new VariableDeclarationExpr(listType, "processes");
+
+            body.addStatement(new AssignExpr(processesField, new ObjectCreationExpr(null, new ClassOrInterfaceType(null, ArrayList.class.getSimpleName()), NodeList.nodeList()), AssignExpr.Operator.ASSIGN));
+
+            for (String processClass : compiledClassNames) {
+                MethodCallExpr addProcess = new MethodCallExpr(new NameExpr("processes"), "add").addArgument(new MethodCallExpr(new NameExpr(processClass), "process"));
+                body.addStatement(addProcess);
+            }
+
+            body.addStatement(new ReturnStmt(new NameExpr("processes")));
+            getProcessesMethod.setBody(body);
+
+            // set work item handlers if found
+            if (!workItemHandlers.isEmpty()) {
+                MethodDeclaration getHandlersMethod = resourceClass.findFirst(MethodDeclaration.class, md -> md.getNameAsString().equals("getWorkItemHandlers")).get();
+                BlockStmt hanldersBody = new BlockStmt();
+
+                ClassOrInterfaceType handlersListType = new ClassOrInterfaceType(null, new SimpleName(List.class.getSimpleName()), NodeList.nodeList(new ClassOrInterfaceType(null, WorkItemHandler.class.getSimpleName())));
+                VariableDeclarationExpr handlersField = new VariableDeclarationExpr(handlersListType, "handlers");
+
+                hanldersBody.addStatement(new AssignExpr(handlersField, new ObjectCreationExpr(null, new ClassOrInterfaceType(null, ArrayList.class.getSimpleName()), NodeList.nodeList()), AssignExpr.Operator.ASSIGN));
+
+                for (Map.Entry<String, String> e : workItemHandlers.entrySet()) {
+                    String workItem = e.getKey();
+                    String handlerClass = e.getValue();
+                    if (handlerClass == null) {
+                        throw new IllegalArgumentException("Cannot find work work item handler for " + workItem);
+                    }
+                    MethodCallExpr addHandler = new MethodCallExpr(new NameExpr("handlers"), "add").addArgument(new ObjectCreationExpr(null, new ClassOrInterfaceType(null, handlerClass), NodeList.nodeList()));
+                    hanldersBody.addStatement(addHandler);
+                }
+
+                hanldersBody.addStatement(new ReturnStmt(new NameExpr("handlers")));
+                getHandlersMethod.setBody(hanldersBody);
+            }
+        }
+
+        return clazz.toString();
+    }
+}

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/process/ResourceGenerator.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/process/ResourceGenerator.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.maven.plugin.process;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.Type;
+import org.drools.core.util.StringUtils;
+import org.kie.api.definition.process.WorkflowProcess;
+
+public class ResourceGenerator {
+
+    private static final String RESOURCE_CLASS_SUFFIX = "Resource";
+    private static final String BOOTSTRAP_PACKAGE = "org.kie.bootstrap.process";
+    private static final String BOOTSTRAP_CLASS = BOOTSTRAP_PACKAGE + ".ProcessRuntimeProvider";
+    private final String relativePath;
+
+    private WorkflowProcess process;
+    private final String packageName;
+    private final String resourceClazzName;
+    private String processId;
+    private String dataClazzName;
+    private String modelfqcn;
+    private final String processName;
+    private boolean hasCdi;
+
+    public ResourceGenerator(
+            WorkflowProcess process,
+            String modelfqcn) {
+        this.process = process;
+        this.packageName = process.getPackageName();
+        this.processId = process.getId();
+        this.processName = processId.substring(processId.lastIndexOf('.') + 1);
+        String classPrefix = StringUtils.capitalize(processName);
+        this.resourceClazzName = classPrefix + "Resource";
+        this.relativePath = packageName.replace(".", "/") + "/" + resourceClazzName + ".java";
+        this.modelfqcn = modelfqcn;
+        this.dataClazzName = modelfqcn.substring(modelfqcn.lastIndexOf('.') + 1);
+    }
+
+    public ResourceGenerator withCdi(boolean hasCdi) {
+        this.hasCdi = hasCdi;
+        return this;
+    }
+
+    public String className() {
+        return resourceClazzName;
+    }
+
+    public String generate() {
+        CompilationUnit clazz = JavaParser.parse(
+                this.getClass().getResourceAsStream("/class-templates/RestResourceTemplate.java"));
+        clazz.setPackageDeclaration(process.getPackageName());
+        clazz.addImport(modelfqcn);
+
+        ClassOrInterfaceDeclaration template =
+                clazz.findFirst(ClassOrInterfaceDeclaration.class).get();
+
+        template.setName(resourceClazzName);
+
+        template.findAll(StringLiteralExpr.class).forEach(this::interpolateStrings);
+        template.findAll(ClassOrInterfaceType.class).forEach(this::interpolateTypes);
+
+        if (hasCdi) {
+            template.findAll(FieldDeclaration.class,
+                             this::isProcessField).forEach(this::annotateFields);
+        }
+
+        return clazz.toString();
+    }
+
+    private boolean isProcessField(FieldDeclaration fd) {
+        return fd.getElementType().asClassOrInterfaceType().getNameAsString().equals("Process");
+    }
+
+    private void annotateFields(FieldDeclaration fd) {
+        fd.addAnnotation("javax.inject.Inject");
+        fd.addSingleMemberAnnotation("javax.inject.Named", new StringLiteralExpr(processId));
+    }
+
+    private void interpolateStrings(StringLiteralExpr vv) {
+        String s = vv.getValue();
+        String documentation =
+                process.getMetaData()
+                        .getOrDefault("Documentation", processName).toString();
+        String interpolated =
+                s.replace("$name$", processName)
+                        .replace("$id$", processId)
+                        .replace("$documentation$", documentation);
+        vv.setString(interpolated);
+    }
+
+    private void interpolateTypes(ClassOrInterfaceType t) {
+        SimpleName returnType = t.asClassOrInterfaceType().getName();
+        interpolateTypes(returnType);
+        t.getTypeArguments().ifPresent(this::interpolateTypeArguments);
+    }
+
+    private void interpolateTypes(SimpleName returnType) {
+        String identifier = returnType.getIdentifier();
+        returnType.setIdentifier(identifier.replace("$Type$", dataClazzName));
+    }
+
+    private void interpolateTypeArguments(NodeList<Type> ta) {
+        ta.stream().map(Type::asClassOrInterfaceType)
+                .forEach(this::interpolateTypes);
+    }
+
+    public String generatedFilePath() {
+        return relativePath;
+    }
+}

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/process/config/WorkItemConfigGenerator.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/process/config/WorkItemConfigGenerator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.maven.plugin.process.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.stmt.SwitchEntryStmt;
+import com.github.javaparser.ast.stmt.SwitchStmt;
+
+public class WorkItemConfigGenerator {
+
+    private static final String RESOURCE = "/class-templates/config/WorkItemConfigTemplate.java";
+    private final Map<String, String> workItemHandlers;
+
+    public WorkItemConfigGenerator(Map<String, String> workItemHandlers) {
+        this.workItemHandlers = new HashMap<>();
+        this.workItemHandlers.put("Log", org.jbpm.process.instance.impl.demo.DoNothingWorkItemHandler.class.getCanonicalName());
+        this.workItemHandlers.put("Human Task", org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler.class.getCanonicalName());
+        this.workItemHandlers.putAll(workItemHandlers);
+    }
+
+    public ClassOrInterfaceDeclaration generate() {
+        ClassOrInterfaceDeclaration cls = JavaParser.parse(this.getClass().getResourceAsStream(RESOURCE))
+                .findFirst(ClassOrInterfaceDeclaration.class).get();
+
+        cls.findFirst(VariableDeclarator.class).ifPresent(this::handlerList);
+        cls.findFirst(SwitchStmt.class).ifPresent(this::generateSwitch);
+
+        return cls;
+    }
+
+    private void generateSwitch(SwitchStmt switchStmt) {
+        for (Map.Entry<String, String> e : workItemHandlers.entrySet()) {
+            switchStmt.addEntry(
+                    new SwitchEntryStmt()
+                            .setLabel(new StringLiteralExpr(e.getKey()))
+                            .addStatement(
+                                    new ReturnStmt(
+                                            new ObjectCreationExpr().setType(e.getValue()))));
+        }
+    }
+
+    private void handlerList(VariableDeclarator vd) {
+        vd.setInitializer(
+                new MethodCallExpr()
+                        .setScope(new NameExpr("java.util.Arrays"))
+                        .setName("asList")
+                        .setArguments(workItemHandlers.keySet().stream().map(StringLiteralExpr::new)
+                                              .collect(Collectors.toCollection(NodeList::new)))
+        );
+    }
+}

--- a/kie-maven-plugin/src/main/resources/class-templates/ModuleTemplate.java
+++ b/kie-maven-plugin/src/main/resources/class-templates/ModuleTemplate.java
@@ -1,0 +1,15 @@
+package $Package$;
+
+import org.kie.submarine.Config;
+
+public class Module {
+
+    private static final Config config =
+            new org.kie.submarine.StaticConfig(
+                    new org.kie.submarine.process.impl.StaticProcessConfig(
+                            new $WorkItemHandlerConfig$()));
+
+    public Config config() {
+        return config;
+    }
+}

--- a/kie-maven-plugin/src/main/resources/class-templates/RestResourceTemplate.java
+++ b/kie-maven-plugin/src/main/resources/class-templates/RestResourceTemplate.java
@@ -32,8 +32,9 @@ public class $Type$Resource {
             resource = new $Type$();
         }
 
-        process.createInstance(resource).start();
-        return resource;
+        ProcessInstance<$Type$> pi = process.createInstance(resource);
+        pi.start();
+        return pi.variables();
     }
 
     @GET()

--- a/kie-maven-plugin/src/main/resources/class-templates/RestResourceTemplate.java
+++ b/kie-maven-plugin/src/main/resources/class-templates/RestResourceTemplate.java
@@ -1,14 +1,74 @@
-package org.kie.rest.codegen;
+package com.myspace.demo;
 
+import java.util.List;
+import java.util.stream.Collectors;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
-import java.util.*;
-import java.util.stream.*;
-import io.swagger.annotations.*;
-import org.kie.api.runtime.process.ProcessInstance;
-import org.jbpm.workflow.instance.impl.WorkflowProcessInstanceImpl;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
-public class XXXResource {
-    
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.kie.submarine.process.Process;
+import org.kie.submarine.process.ProcessInstance;
+
+@Path("/$name$")
+@Api("$documentation$")
+public class $Type$Resource {
+
+    Process<$Type$> process;
+
+    @POST()
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @ApiOperation("Creates new instance of $name$")
+    public $Type$ createResource($Type$ resource) {
+        if (resource == null) {
+            resource = new $Type$();
+        }
+
+        process.createInstance(resource).start();
+        return resource;
+    }
+
+    @GET()
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation("Returns a list of $name$")
+    public List<$Type$> getResources() {
+        return process.instances().values().stream()
+                .map(ProcessInstance::variables)
+                .collect(Collectors.toList());
+    }
+
+    @GET()
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation("Returns information about specified $name$")
+    public $Type$ getResource(@PathParam("id") Long id) {
+        return process.instances()
+                .findById(id)
+                .map(ProcessInstance::variables)
+                .orElse(null);
+    }
+
+    @DELETE()
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation("Cancels specified $name$")
+    public $Type$ deleteResource(@PathParam("id") Long id) {
+        ProcessInstance<$Type$> pi = process.instances()
+                .findById(id)
+                .orElse(null);
+        if (pi == null) {
+            return null;
+        } else {
+            pi.abort();
+            return pi.variables();
+        }
+    }
 }

--- a/kie-maven-plugin/src/main/resources/class-templates/config/WorkItemConfigTemplate.java
+++ b/kie-maven-plugin/src/main/resources/class-templates/config/WorkItemConfigTemplate.java
@@ -1,0 +1,14 @@
+public class ModuleWorkItemHandlerConfig implements org.kie.submarine.process.WorkItemHandlerConfig {
+
+    private static final java.util.List<String> handlers = $values$;
+
+    public org.kie.api.runtime.process.WorkItemHandler forName(String name) {
+        switch (name) {
+        }
+        throw new java.util.NoSuchElementException(name);
+    }
+
+    public java.util.Collection<String> handlers() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
I have took the liberty to refactor some files out of the main Mojo (it makes it more reusable *outside* Maven). Eventually we'll also want to move them in the JBPM tree. This is the structure I usually use (same for Drools). Just wanted @tsurdilo opinion since that's his code (and Maciej's)

## Summary

- We now have a root `Module` class [1]; each module exposes:
- a `Config`
- a set of `Process<XM> createProcessX()` methods, where X is the name of the Process, and XM is the model that has been inferred from the variables in the process. 
- Each `Process<XM>` has a `ProcessInstance<XM> createInstance(XM)` method to return a (typed) ProcessInstance.
- Each `Process<XM>` contains the description of the process using our Process description API.
-  `ProcessInstance<XM>` exposes `start()`, `abort()`, `<T> send(Signal<T>)` etc.
- Each ProcessInstance runs in its own `(Light)ProcessRuntime`, shares (almost) nothing (except some configs, services e.g. ProcessInstanceManager). The upside is that starting a subprocess is literally the same as starting a normal process (`module.createProcessMYSUB().createInstance().start()`). 
In the future we can always extend this to allow runtime sharing. The idea is to make runtimes so light that sharing is unnecessary. Or, equivalently, make it completely stateless so that sharing becomes extremely cheap.  
- Each "public" Process comes with a companion REST Resource, code-generated as well.

Both Process<XM> and ProcessInstance<XM> come with an untyped implementation called `BpmnProcess(Instance)<BpmnVariables>` which will be useful for testing and for legacy/old-style, runtime-oriented coding.
 
## WorkItemHandlerConfig
In short: as discussed with @mswiderski we are now looking for a specific class in `src/main/java`. 
`org.kie.submarine.project.WorkItemHandlerConfig`

This class is usually of the form:

```java
public class WorkItemHandlerConfig extends CachedWorkItemHandlerConfig {{
    register("My Work Item", new MyWorkItemHandler();
    register("My Work Item 2", new MyOtherWorkItemHandler();
    // etc
}}
```

notice that *because of the way it is written* it will be **eagerly** evaluated upon `Module` creation time.

The generated Config either returns an instance of the WorkItemHandlerConfig, if present, or an instance of DefaultWorkItemHandlerConfig otherwise.



[1] This *will* probably be changed to `Application`, but first I have to sort out another problem -- Application should contain both Processes and Rules, right now I have resorted to generate one Module for Processes and one Module for Rules. The idea is that Applications exposes both. Now bear with me for now
