### PR TITLE
JBPM-8458: Code generation in subprocess node may use local data type info

### DIFF
--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/AbstractNodeHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/AbstractNodeHandler.java
@@ -72,9 +72,14 @@ public abstract class AbstractNodeHandler extends BaseAbstractHandler implements
     static final String RUNTIME_SIGNAL_EVENT = "kcontext.getKnowledgeRuntime().signalEvent(";
     static final String RUNTIME_MANAGER_SIGNAL_EVENT = "((org.kie.api.runtime.manager.RuntimeManager)kcontext.getKnowledgeRuntime().getEnvironment().get(\"RuntimeManager\")).signalEvent(";
 
+    public static final String INPUT_TYPES = "BPMN.InputTypes";
+    public static final String OUTPUT_TYPES = "BPMN.OutputTypes";
+
     protected final static String EOL = System.getProperty( "line.separator" );
     protected Map<String, String> dataInputs = new HashMap<String, String>();
+    protected Map<String, String> dataInputTypes = new HashMap<String, String>();
     protected Map<String, String> dataOutputs = new HashMap<String, String>();
+    protected Map<String, String> dataOutputTypes = new HashMap<String, String>();
     protected Map<String, String> inputAssociation = new HashMap<String, String>();
     protected Map<String, String> outputAssociation = new HashMap<String, String>();
 
@@ -108,6 +113,8 @@ public abstract class AbstractNodeHandler extends BaseAbstractHandler implements
         node.setMetaData("UniqueId", id);
         final String name = attrs.getValue("name");
         node.setName(name);
+        node.setMetaData(INPUT_TYPES, dataInputTypes);
+        node.setMetaData(OUTPUT_TYPES, dataOutputTypes);
         if ("true".equalsIgnoreCase(System.getProperty("jbpm.v5.id.strategy"))) {
             try {
                 // remove starting _
@@ -333,19 +340,23 @@ public abstract class AbstractNodeHandler extends BaseAbstractHandler implements
     	}
     }
 
-    protected void readIoSpecification(org.w3c.dom.Node xmlNode, Map<String, String> dataInputs, Map<String, String> dataOutputs) {
+    protected void readIoSpecification(org.w3c.dom.Node xmlNode, Map<String, String> dataInputs, Map<String, String> dataOutputs, Map<String, String> dataInputTypes, Map<String, String> dataOutputTypes) {
         org.w3c.dom.Node subNode = xmlNode.getFirstChild();
         while (subNode instanceof Element) {
             String subNodeName = subNode.getNodeName();
             if ("dataInput".equals(subNodeName)) {
                 String id = ((Element) subNode).getAttribute("id");
                 String inputName = ((Element) subNode).getAttribute("name");
+                String type = ((Element) subNode).getAttribute("dtype");
                 dataInputs.put(id, inputName);
+                dataInputTypes.put(inputName, type);
             }
             if ("dataOutput".equals(subNodeName)) {
                 String id = ((Element) subNode).getAttribute("id");
                 String outputName = ((Element) subNode).getAttribute("name");
+                String type = ((Element) subNode).getAttribute("dtype");
                 dataOutputs.put(id, outputName);
+                dataOutputTypes.put(outputName, type);
             }
             subNode = subNode.getNextSibling();
         }

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/BusinessRuleTaskHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/BusinessRuleTaskHandler.java
@@ -69,7 +69,7 @@ public class BusinessRuleTaskHandler extends AbstractNodeHandler {
 		while (xmlNode != null) {
             String nodeName = xmlNode.getNodeName();
             if ("ioSpecification".equals(nodeName)) {
-                readIoSpecification(xmlNode, dataInputs, dataOutputs);
+                readIoSpecification(xmlNode, dataInputs, dataOutputs, dataInputTypes, dataOutputTypes);
             } else if ("dataInputAssociation".equals(nodeName)) {
                 readDataInputAssociation(xmlNode, ruleSetNode, dataInputs);
             } else if ("dataOutputAssociation".equals(nodeName)) {

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/CallActivityHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/CallActivityHandler.java
@@ -29,7 +29,6 @@ import org.jbpm.workflow.core.impl.NodeImpl;
 import org.jbpm.workflow.core.node.ForEachNode;
 import org.jbpm.workflow.core.node.SubProcessNode;
 import org.jbpm.workflow.core.node.Transformation;
-import org.jbpm.workflow.core.node.WorkItemNode;
 import org.kie.api.runtime.process.DataTransformer;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -75,7 +74,7 @@ public class CallActivityHandler extends AbstractNodeHandler {
         while (xmlNode != null) {
         	String nodeName = xmlNode.getNodeName();
         	if ("ioSpecification".equals(nodeName)) {
-        		readIoSpecification(xmlNode, dataInputs, dataOutputs);
+        		readIoSpecification(xmlNode, dataInputs, dataOutputs, dataInputTypes, dataOutputTypes);
         	} else if ("dataInputAssociation".equals(nodeName)) {
         		readDataInputAssociation(xmlNode, subProcessNode, dataInputs);
         	} else if ("dataOutputAssociation".equals(nodeName)) {
@@ -139,7 +138,7 @@ public class CallActivityHandler extends AbstractNodeHandler {
         return node;
     }
 
-    protected void readIoSpecification(org.w3c.dom.Node xmlNode, Map<String, String> dataInputs, Map<String, String> dataOutputs) {
+    protected void readIoSpecification(org.w3c.dom.Node xmlNode, Map<String, String> dataInputs, Map<String, String> dataOutputs, Map<String, String> dataInputTypes, Map<String, String> dataOutputTypes) {
     	org.w3c.dom.Node subNode = xmlNode.getFirstChild();
 		while (subNode instanceof Element) {
 			String subNodeName = subNode.getNodeName();
@@ -147,11 +146,15 @@ public class CallActivityHandler extends AbstractNodeHandler {
         		String id = ((Element) subNode).getAttribute("id");
         		String inputName = ((Element) subNode).getAttribute("name");
         		dataInputs.put(id, inputName);
+				String type = ((Element) subNode).getAttribute("dtype");
+				dataInputTypes.put(inputName, type);
         	} else if ("dataOutput".equals(subNodeName)) {
         		String id = ((Element) subNode).getAttribute("id");
         		String outputName = ((Element) subNode).getAttribute("name");
         		dataOutputs.put(id, outputName);
-        	}
+				String type = ((Element) subNode).getAttribute("dtype");
+				dataOutputTypes.put(outputName, type);
+			}
         	subNode = subNode.getNextSibling();
 		}
     }

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ProcessHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ProcessHandler.java
@@ -170,7 +170,7 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
 		
 		// for unique id's of nodes, start with one to avoid returning wrong nodes for dynamic nodes
 		parser.getMetaData().put("idGen", new AtomicInteger(1));
-		
+
 		return process;
 	}
 

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/SubProcessHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/SubProcessHandler.java
@@ -155,7 +155,7 @@ public class SubProcessHandler extends AbstractNodeHandler {
         while (xmlNode != null) {
             String nodeName = xmlNode.getNodeName();
             if ("ioSpecification".equals(nodeName)) {
-                readIoSpecification(xmlNode, dataInputs, dataOutputs);
+                readIoSpecification(xmlNode, dataInputs, dataOutputs, dataInputTypes, dataOutputTypes);
             } else if ("dataInputAssociation".equals(nodeName)) {
                 readDataInputAssociation(xmlNode, inputAssociation);
             } else if ("dataOutputAssociation".equals(nodeName)) {

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/TaskHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/TaskHandler.java
@@ -76,7 +76,7 @@ public class TaskHandler extends AbstractNodeHandler {
         while (xmlNode != null) {
         	String nodeName = xmlNode.getNodeName();
         	if ("ioSpecification".equals(nodeName)) {
-        		readIoSpecification(xmlNode, dataInputs, dataOutputs);
+        		readIoSpecification(xmlNode, dataInputs, dataOutputs, dataInputTypes);
         	} else if ("dataInputAssociation".equals(nodeName)) {
         		readDataInputAssociation(xmlNode, workItemNode, dataInputs);
         	} else if ("dataOutputAssociation".equals(nodeName)) {
@@ -102,7 +102,7 @@ public class TaskHandler extends AbstractNodeHandler {
         return element.getAttribute("taskName");
     }
     
-    protected void readIoSpecification(org.w3c.dom.Node xmlNode, Map<String, String> dataInputs, Map<String, String> dataOutputs) {
+    protected void readIoSpecification(org.w3c.dom.Node xmlNode, Map<String, String> dataInputs, Map<String, String> dataOutputs, Map<String, String> dataInputTypes) {
         
         dataTypeInputs.clear();
         dataTypeOutputs.clear();

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessMetaData.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessMetaData.java
@@ -23,6 +23,8 @@ import com.github.javaparser.ast.CompilationUnit;
 
 public class ProcessMetaData {
 
+    private final String processPackageName;
+    private final String processBaseClassName;
     private String processClassName;
 
     private String processId;
@@ -37,13 +39,25 @@ public class ProcessMetaData {
 
     private Set<String> workItems = new HashSet<>();
 
-    public ProcessMetaData(String processId, String extractedProcessId, String processName, String processVersion, String processClassName) {
+    public ProcessMetaData(String processId, String extractedProcessId, String processName, String processVersion, String processPackageName, String processClassName) {
         super();
         this.processId = processId;
         this.extractedProcessId = extractedProcessId;
         this.processName = processName;
         this.processVersion = processVersion;
-        this.processClassName = processClassName;
+        this.processPackageName = processPackageName;
+        this.processClassName = processPackageName == null ?
+                processClassName :
+                processPackageName + "." + processClassName;
+        this.processBaseClassName = processClassName;
+    }
+
+    public String getPackageName() {
+        return processPackageName;
+    }
+
+    public String getProcessBaseClassName() {
+        return processBaseClassName;
     }
 
     public String getProcessClassName() {
@@ -104,9 +118,9 @@ public class ProcessMetaData {
 
     @Override
     public String toString() {
-        return "ProcessMetaData [processClassName=" + processClassName + 
-                ", processId=" + processId + ", extractedProcessId=" + extractedProcessId + 
+        return "ProcessMetaData [processClassName=" + processClassName +
+                ", processId=" + processId + ", extractedProcessId=" + extractedProcessId +
                 ", processName=" + processName + ", processVersion=" + processVersion +
-               ", workItems=" + workItems + "]";
+                ", workItems=" + workItems + "]";
     }
 }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessToExecModelGenerator.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessToExecModelGenerator.java
@@ -28,7 +28,6 @@ import java.util.Set;
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.AssignExpr;
@@ -43,7 +42,6 @@ import com.github.javaparser.ast.nodeTypes.NodeWithName;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
-
 import org.drools.core.util.StringUtils;
 import org.jbpm.process.core.ContextContainer;
 import org.jbpm.process.core.Work;
@@ -65,7 +63,6 @@ import org.kie.api.definition.process.Connection;
 import org.kie.api.definition.process.Node;
 import org.kie.api.definition.process.NodeContainer;
 import org.kie.api.definition.process.WorkflowProcess;
-import org.w3c.dom.NamedNodeMap;
 
 public class ProcessToExecModelGenerator extends AbstractVisitor {
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/VariableDeclarations.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/VariableDeclarations.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.compiler.canonical;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jbpm.process.core.context.variable.Variable;
+import org.jbpm.process.core.context.variable.VariableScope;
+
+public interface VariableDeclarations {
+
+    String getType(String vname);
+
+    Map<String, String> getTypes();
+
+    static VariableDeclarations of(VariableScope vscope) {
+        HashMap<String, String> vs = new HashMap<>();
+        for (Variable variable : vscope.getVariables()) {
+            vs.put(variable.getName(), variable.getType().getStringType());
+        }
+        return of(vs);
+    }
+
+    static VariableDeclarations of(Map<String, String> vscope) {
+        return new VariableDeclarations() {
+            @Override
+            public String getType(String vname) {
+                return vscope.get(vname);
+            }
+
+            @Override
+            public Map<String, String> getTypes() {
+                return vscope;
+            }
+        };
+    }
+}

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/VariableDeclarations.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/VariableDeclarations.java
@@ -21,13 +21,9 @@ import java.util.Map;
 import org.jbpm.process.core.context.variable.Variable;
 import org.jbpm.process.core.context.variable.VariableScope;
 
-public interface VariableDeclarations {
+public class VariableDeclarations {
 
-    String getType(String vname);
-
-    Map<String, String> getTypes();
-
-    static VariableDeclarations of(VariableScope vscope) {
+    public static VariableDeclarations of(VariableScope vscope) {
         HashMap<String, String> vs = new HashMap<>();
         for (Variable variable : vscope.getVariables()) {
             vs.put(variable.getName(), variable.getType().getStringType());
@@ -35,17 +31,21 @@ public interface VariableDeclarations {
         return of(vs);
     }
 
-    static VariableDeclarations of(Map<String, String> vscope) {
-        return new VariableDeclarations() {
-            @Override
-            public String getType(String vname) {
-                return vscope.get(vname);
-            }
+    public static VariableDeclarations of(Map<String, String> vscope) {
+        return new VariableDeclarations(vscope);
+    }
 
-            @Override
-            public Map<String, String> getTypes() {
-                return vscope;
-            }
-        };
+    private final Map<String, String> vscope;
+
+    public VariableDeclarations(Map<String, String> vscope) {
+        this.vscope = vscope;
+    }
+
+    public String getType(String vname) {
+        return vscope.get(vname);
+    }
+
+    public Map<String, String> getTypes() {
+        return vscope;
     }
 }

--- a/submarine-codegen/src/main/java/org/kie/submarine/codegen/process/ProcessCodegen.java
+++ b/submarine-codegen/src/main/java/org/kie/submarine/codegen/process/ProcessCodegen.java
@@ -72,7 +72,7 @@ public class ProcessCodegen implements Generator {
         return ofFiles(files);
     }
 
-    public static ProcessCodegen ofFiles(List<File> processFiles) throws IOException {
+    public static ProcessCodegen ofFiles(Collection<File> processFiles) throws IOException {
         List<Process> allProcesses = parseProcesses(processFiles);
         return ofProcesses(allProcesses);
     }
@@ -81,7 +81,7 @@ public class ProcessCodegen implements Generator {
         return new ProcessCodegen(processes);
     }
 
-    private static List<Process> parseProcesses(List<File> processFiles) throws IOException {
+    private static List<Process> parseProcesses(Collection<File> processFiles) throws IOException {
         List<Process> processes = new ArrayList<>();
         for (File bpmnFile : processFiles) {
             FileSystemResource r = new FileSystemResource(bpmnFile);


### PR DESCRIPTION
when calling into a SubProcess we need to have info about the variables that we are going to bind/unbind. Instead of requiring full pre-analysis of all processes, we can use local type information that we have in our BPMN2 files:

e.g.:

```xml
    <bpmn2:callActivity calledElement="demo.orderItems"> 
      <bpmn2:ioSpecification>
        <bpmn2:dataInput drools:dtype="com.myspace.demo.Order" name="order"/>
```

