### PR TITLE
DROOLS-3978 Add first bunch of unit tests for submarine-codegen

### DIFF
--- a/submarine-codegen/pom.xml
+++ b/submarine-codegen/pom.xml
@@ -79,7 +79,7 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
-    
+
     <!-- test -->
     <dependency>
       <groupId>org.junit.vintage</groupId>
@@ -96,7 +96,7 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
-        
+
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-core-static</artifactId>
@@ -115,6 +115,16 @@
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
       <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/submarine-codegen/pom.xml
+++ b/submarine-codegen/pom.xml
@@ -51,7 +51,7 @@
     </dependencies>
   </dependencyManagement>
 
-  
+
   <dependencies>
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -69,7 +69,7 @@
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-bpmn2</artifactId>
     </dependency>
-    
+
     <!-- image metadata handling -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -128,6 +128,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-
 </project>

--- a/submarine-codegen/src/main/java/org/kie/submarine/codegen/ApplicationGenerator.java
+++ b/submarine-codegen/src/main/java/org/kie/submarine/codegen/ApplicationGenerator.java
@@ -17,6 +17,7 @@ package org.kie.submarine.codegen;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -38,6 +39,7 @@ import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 
+// TODO add edge cases, illegal input tests etc.
 public class ApplicationGenerator {
 
     private static final String RESOURCE = "/class-templates/ApplicationTemplate.java";
@@ -115,7 +117,9 @@ public class ApplicationGenerator {
         generators.forEach(gen -> gen.updateConfig(configGenerator));
         generators.forEach(gen -> factoryMethods.addAll(gen.factoryMethods()));        
         generators.forEach(gen -> writeLabelsImageMetadata(gen.getLabels()));
-        generatedFiles.add(new GeneratedFile(GeneratedFile.Type.APPLICATION, generatedFilePath(), compilationUnit().toString().getBytes()));
+        generatedFiles.add(new GeneratedFile(GeneratedFile.Type.APPLICATION,
+                                             generatedFilePath(),
+                                             compilationUnit().toString().getBytes(StandardCharsets.UTF_8)));
         return generatedFiles;
     }
 
@@ -139,9 +143,10 @@ public class ApplicationGenerator {
             }
             imageMetadata.add(labels);
             
-            Files.write(imageMetaDataFile, mapper.writerWithDefaultPrettyPrinter().writeValueAsString(imageMetadata).getBytes());
+            Files.write(imageMetaDataFile,
+                        mapper.writerWithDefaultPrettyPrinter().writeValueAsString(imageMetadata).getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {
-//            throw new RuntimeException(e);
+            throw new RuntimeException(e);
         }
                
     }

--- a/submarine-codegen/src/main/java/org/kie/submarine/codegen/ApplicationGenerator.java
+++ b/submarine-codegen/src/main/java/org/kie/submarine/codegen/ApplicationGenerator.java
@@ -60,6 +60,9 @@ public class ApplicationGenerator {
     private List<Generator> generators = new ArrayList<>();
 
     public ApplicationGenerator(String packageName, File targetDirectory) {
+        if (packageName == null) {
+            throw new IllegalArgumentException("Package name cannot be undefined (null), please specify a package name!");
+        }
         this.packageName = packageName;
         this.targetDirectory = targetDirectory;
         this.targetTypeName = "Application";
@@ -131,10 +134,9 @@ public class ApplicationGenerator {
     }
     
     protected void writeLabelsImageMetadata(Map<String, String> labels) {
-        
         try {
             Path imageMetaDataFile = Paths.get(targetDirectory.getAbsolutePath(), "image_metadata.json");
-            ImageMetaData imageMetadata = null;
+            ImageMetaData imageMetadata;
             if (Files.exists(imageMetaDataFile)) {
                 // read the file to merge the content
                 imageMetadata =  mapper.readValue(imageMetaDataFile.toFile(), ImageMetaData.class);

--- a/submarine-codegen/src/main/java/org/kie/submarine/codegen/ApplicationGenerator.java
+++ b/submarine-codegen/src/main/java/org/kie/submarine/codegen/ApplicationGenerator.java
@@ -39,7 +39,6 @@ import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 
-// TODO add edge cases, illegal input tests etc.
 public class ApplicationGenerator {
 
     private static final String RESOURCE = "/class-templates/ApplicationTemplate.java";
@@ -144,7 +143,8 @@ public class ApplicationGenerator {
                 imageMetadata = new ImageMetaData();            
             }
             imageMetadata.add(labels);
-            
+
+            Files.createDirectories(imageMetaDataFile.getParent());
             Files.write(imageMetaDataFile,
                         mapper.writerWithDefaultPrettyPrinter().writeValueAsString(imageMetadata).getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {

--- a/submarine-codegen/src/main/java/org/kie/submarine/codegen/ApplicationGenerator.java
+++ b/submarine-codegen/src/main/java/org/kie/submarine/codegen/ApplicationGenerator.java
@@ -141,7 +141,7 @@ public class ApplicationGenerator {
             
             Files.write(imageMetaDataFile, mapper.writerWithDefaultPrettyPrinter().writeValueAsString(imageMetadata).getBytes());
         } catch (IOException e) {
-            
+//            throw new RuntimeException(e);
         }
                
     }

--- a/submarine-codegen/src/test/java/org/kie/submarine/codegen/ApplicationGeneratorTest.java
+++ b/submarine-codegen/src/test/java/org/kie/submarine/codegen/ApplicationGeneratorTest.java
@@ -2,16 +2,28 @@ package org.kie.submarine.codegen;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
-import org.mockito.Mockito;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ApplicationGeneratorTest {
 
@@ -21,53 +33,139 @@ public class ApplicationGeneratorTest {
     @Test
     public void targetCanonicalName() {
         final ApplicationGenerator appGenerator = new ApplicationGenerator(PACKAGE_NAME, new File(""));
-        Assertions.assertThat(appGenerator.targetCanonicalName()).isEqualTo(EXPECTED_APPLICATION_NAME);
+        assertThat(appGenerator.targetCanonicalName()).isNotNull();
+        assertThat(appGenerator.targetCanonicalName()).isEqualTo(EXPECTED_APPLICATION_NAME);
     }
 
     @Test
     public void generatedFilePath() {
         final ApplicationGenerator appGenerator = new ApplicationGenerator(PACKAGE_NAME, new File(""));
-        Assertions.assertThat(appGenerator.generatedFilePath()).isEqualTo(EXPECTED_APPLICATION_NAME.replace(".", "/") + ".java");
-    }
-
-    @Test
-    public void addFactoryMethods() {
+        assertThat(appGenerator.generatedFilePath()).isNotNull();
+        assertThat(appGenerator.generatedFilePath()).isEqualTo(EXPECTED_APPLICATION_NAME.replace(".", "/") + ".java");
     }
 
     @Test
     public void compilationUnit() {
+        final ApplicationGenerator appGenerator = new ApplicationGenerator(PACKAGE_NAME, new File("target"));
+        assertCompilationUnit(appGenerator.compilationUnit(), false, 0);
     }
 
     @Test
-    public void withDependencyInjection() {
-        final ApplicationGenerator appGenerator = new ApplicationGenerator(PACKAGE_NAME, new File(""));
-        Assertions.assertThat(appGenerator.withDependencyInjection(false)).isSameAs(appGenerator);
+    public void compilationUnitWithCDI() {
+        final ApplicationGenerator initialAppGenerator = new ApplicationGenerator(PACKAGE_NAME, new File("target"));
+        final ApplicationGenerator appGenerator = initialAppGenerator.withDependencyInjection(true);
+        assertThat(appGenerator).isSameAs(initialAppGenerator);
+        assertCompilationUnit(appGenerator.compilationUnit(), true, 0);
+    }
 
-        // TODO - check that dep. injection is not set
+    @Test
+    public void compilationUnitWithFactoryMethods() {
+        final ApplicationGenerator appGenerator = new ApplicationGenerator(PACKAGE_NAME, new File("target"));
+        final String testMethodName = "testMethod";
+        final MethodDeclaration methodDeclaration = new MethodDeclaration();
+        methodDeclaration.setName(testMethodName);
 
-        // TODO - check that dep. injection is set
+        appGenerator.addFactoryMethods(Collections.singleton(methodDeclaration));
+
+        final CompilationUnit compilationUnit = appGenerator.compilationUnit();
+        assertCompilationUnit(compilationUnit, false, 1);
+
+        final TypeDeclaration mainAppClass = compilationUnit.getTypes().get(0);
+        assertThat(mainAppClass.getMembers()
+                           .stream()
+                           .filter(member -> member instanceof MethodDeclaration
+                                   && ((MethodDeclaration) member).getName().toString().equals(testMethodName)))
+                .hasSize(1);
     }
 
     @Test
     public void generate() {
+        final ApplicationGenerator appGenerator = new ApplicationGenerator(PACKAGE_NAME, new File("target"));
+        final Collection<GeneratedFile> generatedFiles = appGenerator.generate();
+        assertThat(generatedFiles).isNotNull();
+        assertThat(generatedFiles).hasSize(1);
+
+        final GeneratedFile generatedFile = generatedFiles.iterator().next();
+        assertThat(generatedFile).isNotNull();
+        assertThat(generatedFile.getType()).isEqualTo(GeneratedFile.Type.APPLICATION);
+        assertThat(generatedFile.relativePath()).isEqualTo(EXPECTED_APPLICATION_NAME.replace(".", "/") + ".java");
+        assertThat(generatedFile.contents()).isEqualTo(appGenerator.compilationUnit().toString().getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
-    public void withGenerator() {
+    public void generateWithOtherGenerator() {
     }
 
     @Test
     public void writeLabelsImageMetadata() throws IOException {
-//        final Path tempDirectory = Files.createTempDirectory("wlim");
-//        final ApplicationGenerator appGenerator = new ApplicationGenerator(PACKAGE_NAME, tempDirectory.toFile());
-//
-//        final Map<String, String> labels = new HashMap<>();
-//        labels.put("testKey1", "testValue1");
-//        labels.put("testKey2", "testValue2");
-//        labels.put("testKey3", "testValue3");
-//
-//        appGenerator.writeLabelsImageMetadata(labels);
+        final Path targetDirectory = Paths.get("target");
+        final ApplicationGenerator appGenerator = new ApplicationGenerator(PACKAGE_NAME, targetDirectory.toFile());
 
-        // TODO test file exists and contains the labels and values
+        final Map<String, String> labels = new HashMap<>();
+        labels.put("testKey1", "testValue1");
+        labels.put("testKey2", "testValue2");
+        labels.put("testKey3", "testValue3");
+
+        appGenerator.writeLabelsImageMetadata(labels);
+
+        try (Stream<Path> stream = Files.walk(targetDirectory, 1)) {
+            final Optional<Path> generatedFile = stream
+                    .filter(file -> file.getFileName().toString().equals("image_metadata.json"))
+                    .findFirst();
+            assertThat(generatedFile).isPresent();
+
+            ObjectMapper mapper = new ObjectMapper();
+            final Map<String, List> elementsFromFile = mapper.readValue(generatedFile.get().toFile(),
+                                                                        new TypeReference<Map<String, List>>(){});
+            assertThat(elementsFromFile).hasSize(1);
+            final List<Map<String, String>> listWithLabelsMap = elementsFromFile.entrySet().iterator().next().getValue();
+            assertThat(listWithLabelsMap).isNotNull();
+            assertThat(listWithLabelsMap).hasSize(1);
+            assertThat(listWithLabelsMap.get(0)).containsAllEntriesOf(labels);
+        }
+    }
+
+    private void assertCompilationUnit(final CompilationUnit compilationUnit, final boolean checkCDI, final int expectedNumberOfFactoryMethods) {
+        assertThat(compilationUnit).isNotNull();
+
+        assertThat(compilationUnit.getPackageDeclaration()).isPresent();
+        assertThat(compilationUnit.getPackageDeclaration().get().getName().toString()).isEqualTo(PACKAGE_NAME);
+
+        assertThat(compilationUnit.getImports()).isNotNull();
+        assertThat(compilationUnit.getImports()).hasSize(1);
+        assertThat(compilationUnit.getImports().get(0).getName().toString()).isEqualTo("org.kie.submarine.Config");
+
+        assertThat(compilationUnit.getTypes()).isNotNull();
+        assertThat(compilationUnit.getTypes()).hasSize(1);
+
+        final TypeDeclaration mainAppClass = compilationUnit.getTypes().get(0);
+        assertThat(mainAppClass).isNotNull();
+        assertThat(mainAppClass.getName().toString()).isEqualTo("Application");
+
+        if (checkCDI) {
+            assertThat(mainAppClass.getAnnotations()).isNotEmpty();
+            assertThat(mainAppClass.getAnnotationByName("Singleton")).isPresent();
+        } else {
+            assertThat(mainAppClass.getAnnotationByName("Singleton")).isNotPresent();
+        }
+
+        assertThat(mainAppClass.getMembers()).isNotNull();
+        assertThat(mainAppClass.getMembers()).hasSize(2 + expectedNumberOfFactoryMethods);
+
+        assertThat(mainAppClass.getMembers()
+                           .stream()
+                           .filter(member -> member instanceof MethodDeclaration
+                                   && ((MethodDeclaration) member).getName().toString().equals("config")
+                                   && !((MethodDeclaration) member).isStatic()))
+                .hasSize(1);
+        assertThat(mainAppClass.getMembers()
+                           .stream()
+                           .filter(member -> member instanceof FieldDeclaration
+                                   && ((FieldDeclaration) member).getVariable(0).getName().toString().equals("config")
+                                   && ((FieldDeclaration) member).isStatic()))
+                .hasSize(1);
+
+        assertThat(mainAppClass.getMember(0)).isInstanceOfAny(MethodDeclaration.class, FieldDeclaration.class);
+        assertThat(mainAppClass.getMember(1)).isInstanceOfAny(MethodDeclaration.class, FieldDeclaration.class);
     }
 }

--- a/submarine-codegen/src/test/java/org/kie/submarine/codegen/ApplicationGeneratorTest.java
+++ b/submarine-codegen/src/test/java/org/kie/submarine/codegen/ApplicationGeneratorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.submarine.codegen;
 
 import java.io.File;

--- a/submarine-codegen/src/test/java/org/kie/submarine/codegen/ApplicationGeneratorTest.java
+++ b/submarine-codegen/src/test/java/org/kie/submarine/codegen/ApplicationGeneratorTest.java
@@ -1,0 +1,73 @@
+package org.kie.submarine.codegen;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.*;
+
+public class ApplicationGeneratorTest {
+
+    private static final String PACKAGE_NAME = "org.drools.test";
+    private static final String EXPECTED_APPLICATION_NAME = PACKAGE_NAME + ".Application";
+
+    @Test
+    public void targetCanonicalName() {
+        final ApplicationGenerator appGenerator = new ApplicationGenerator(PACKAGE_NAME, new File(""));
+        Assertions.assertThat(appGenerator.targetCanonicalName()).isEqualTo(EXPECTED_APPLICATION_NAME);
+    }
+
+    @Test
+    public void generatedFilePath() {
+        final ApplicationGenerator appGenerator = new ApplicationGenerator(PACKAGE_NAME, new File(""));
+        Assertions.assertThat(appGenerator.generatedFilePath()).isEqualTo(EXPECTED_APPLICATION_NAME.replace(".", "/") + ".java");
+    }
+
+    @Test
+    public void addFactoryMethods() {
+    }
+
+    @Test
+    public void compilationUnit() {
+    }
+
+    @Test
+    public void withDependencyInjection() {
+        final ApplicationGenerator appGenerator = new ApplicationGenerator(PACKAGE_NAME, new File(""));
+        Assertions.assertThat(appGenerator.withDependencyInjection(false)).isSameAs(appGenerator);
+
+        // TODO - check that dep. injection is not set
+
+        // TODO - check that dep. injection is set
+    }
+
+    @Test
+    public void generate() {
+    }
+
+    @Test
+    public void withGenerator() {
+    }
+
+    @Test
+    public void writeLabelsImageMetadata() throws IOException {
+//        final Path tempDirectory = Files.createTempDirectory("wlim");
+//        final ApplicationGenerator appGenerator = new ApplicationGenerator(PACKAGE_NAME, tempDirectory.toFile());
+//
+//        final Map<String, String> labels = new HashMap<>();
+//        labels.put("testKey1", "testValue1");
+//        labels.put("testKey2", "testValue2");
+//        labels.put("testKey3", "testValue3");
+//
+//        appGenerator.writeLabelsImageMetadata(labels);
+
+        // TODO test file exists and contains the labels and values
+    }
+}

--- a/submarine-codegen/src/test/java/org/kie/submarine/codegen/ApplicationGeneratorTest.java
+++ b/submarine-codegen/src/test/java/org/kie/submarine/codegen/ApplicationGeneratorTest.java
@@ -164,7 +164,7 @@ public class ApplicationGeneratorTest {
         assertThat(compilationUnit.getPackageDeclaration().get().getName().toString()).isEqualTo(PACKAGE_NAME);
 
         assertThat(compilationUnit.getImports()).isNotNull();
-        assertThat(compilationUnit.getImports()).hasSize(1);
+        assertThat(compilationUnit.getImports()).hasSize(2);
         assertThat(compilationUnit.getImports().get(0).getName().toString()).isEqualTo("org.kie.submarine.Config");
 
         assertThat(compilationUnit.getTypes()).isNotNull();

--- a/submarine-codegen/src/test/java/org/kie/submarine/codegen/ConfigGeneratorTest.java
+++ b/submarine-codegen/src/test/java/org/kie/submarine/codegen/ConfigGeneratorTest.java
@@ -63,7 +63,7 @@ public class ConfigGeneratorTest {
         assertThat(expression.getType().asString()).isEqualTo(StaticConfig.class.getCanonicalName());
 
         assertThat(expression.getArguments()).isNotNull();
-        assertThat(expression.getArguments()).hasSize(1);
+        assertThat(expression.getArguments()).hasSize(2);
         assertThat(expression.getArgument(0)).isInstanceOf(expectedArgumentType);
     }
 }

--- a/submarine-codegen/src/test/java/org/kie/submarine/codegen/ConfigGeneratorTest.java
+++ b/submarine-codegen/src/test/java/org/kie/submarine/codegen/ConfigGeneratorTest.java
@@ -30,17 +30,17 @@ public class ConfigGeneratorTest {
 
     @Test
     public void newInstanceNoProcessConfig() {
-        newInstance(null, NullLiteralExpr.class);
+        newInstanceTest(null, NullLiteralExpr.class);
     }
 
     @Test
     public void newInstanceWithProcessConfig() {
         final ProcessConfigGenerator processConfigGenerator = Mockito.mock(ProcessConfigGenerator.class);
         Mockito.when(processConfigGenerator.newInstance()).thenReturn(new ObjectCreationExpr());
-        newInstance(processConfigGenerator, ObjectCreationExpr.class);
+        newInstanceTest(processConfigGenerator, ObjectCreationExpr.class);
     }
 
-    private void newInstance(final ProcessConfigGenerator processConfigGenerator, final Class expectedArgumentType) {
+    private void newInstanceTest(final ProcessConfigGenerator processConfigGenerator, final Class expectedArgumentType) {
         ObjectCreationExpr expression = new ConfigGenerator().withProcessConfig(processConfigGenerator).newInstance();
         assertThat(expression).isNotNull();
 

--- a/submarine-codegen/src/test/java/org/kie/submarine/codegen/ConfigGeneratorTest.java
+++ b/submarine-codegen/src/test/java/org/kie/submarine/codegen/ConfigGeneratorTest.java
@@ -2,11 +2,12 @@ package org.kie.submarine.codegen;
 
 import com.github.javaparser.ast.expr.NullLiteralExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.kie.submarine.StaticConfig;
 import org.kie.submarine.codegen.process.config.ProcessConfigGenerator;
 import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConfigGeneratorTest {
 
@@ -14,13 +15,17 @@ public class ConfigGeneratorTest {
     public void withProcessConfig() {
         final ConfigGenerator generator = new ConfigGenerator();
         final ProcessConfigGenerator processConfigGenerator = Mockito.mock(ProcessConfigGenerator.class);
-        Assertions.assertThat(generator.withProcessConfig(processConfigGenerator)).isSameAs(generator);
+        final ConfigGenerator returnedConfigGenerator = generator.withProcessConfig(processConfigGenerator);
+        assertThat(returnedConfigGenerator).isNotNull();
+        assertThat(returnedConfigGenerator).isSameAs(generator);
     }
 
     @Test
     public void withProcessConfigNull() {
         final ConfigGenerator generator = new ConfigGenerator();
-        Assertions.assertThat(generator.withProcessConfig(null)).isSameAs(generator);
+        final ConfigGenerator returnedConfigGenerator = generator.withProcessConfig(null);
+        assertThat(returnedConfigGenerator).isNotNull();
+        assertThat(returnedConfigGenerator).isSameAs(generator);
     }
 
     @Test
@@ -37,8 +42,13 @@ public class ConfigGeneratorTest {
 
     private void newInstance(final ProcessConfigGenerator processConfigGenerator, final Class expectedArgumentType) {
         ObjectCreationExpr expression = new ConfigGenerator().withProcessConfig(processConfigGenerator).newInstance();
-        Assertions.assertThat(expression.getType().asString()).isEqualTo(StaticConfig.class.getCanonicalName());
-        Assertions.assertThat(expression.getArguments()).hasSize(1);
-        Assertions.assertThat(expression.getArgument(0)).isInstanceOf(expectedArgumentType);
+        assertThat(expression).isNotNull();
+
+        assertThat(expression.getType()).isNotNull();
+        assertThat(expression.getType().asString()).isEqualTo(StaticConfig.class.getCanonicalName());
+
+        assertThat(expression.getArguments()).isNotNull();
+        assertThat(expression.getArguments()).hasSize(1);
+        assertThat(expression.getArgument(0)).isInstanceOf(expectedArgumentType);
     }
 }

--- a/submarine-codegen/src/test/java/org/kie/submarine/codegen/ConfigGeneratorTest.java
+++ b/submarine-codegen/src/test/java/org/kie/submarine/codegen/ConfigGeneratorTest.java
@@ -1,0 +1,44 @@
+package org.kie.submarine.codegen;
+
+import com.github.javaparser.ast.expr.NullLiteralExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.kie.submarine.StaticConfig;
+import org.kie.submarine.codegen.process.config.ProcessConfigGenerator;
+import org.mockito.Mockito;
+
+public class ConfigGeneratorTest {
+
+    @Test
+    public void withProcessConfig() {
+        final ConfigGenerator generator = new ConfigGenerator();
+        final ProcessConfigGenerator processConfigGenerator = Mockito.mock(ProcessConfigGenerator.class);
+        Assertions.assertThat(generator.withProcessConfig(processConfigGenerator)).isSameAs(generator);
+    }
+
+    @Test
+    public void withProcessConfigNull() {
+        final ConfigGenerator generator = new ConfigGenerator();
+        Assertions.assertThat(generator.withProcessConfig(null)).isSameAs(generator);
+    }
+
+    @Test
+    public void newInstanceNoProcessConfig() {
+        newInstance(null, NullLiteralExpr.class);
+    }
+
+    @Test
+    public void newInstanceWithProcessConfig() {
+        final ProcessConfigGenerator processConfigGenerator = Mockito.mock(ProcessConfigGenerator.class);
+        Mockito.when(processConfigGenerator.newInstance()).thenReturn(new ObjectCreationExpr());
+        newInstance(processConfigGenerator, ObjectCreationExpr.class);
+    }
+
+    private void newInstance(final ProcessConfigGenerator processConfigGenerator, final Class expectedArgumentType) {
+        ObjectCreationExpr expression = new ConfigGenerator().withProcessConfig(processConfigGenerator).newInstance();
+        Assertions.assertThat(expression.getType().asString()).isEqualTo(StaticConfig.class.getCanonicalName());
+        Assertions.assertThat(expression.getArguments()).hasSize(1);
+        Assertions.assertThat(expression.getArgument(0)).isInstanceOf(expectedArgumentType);
+    }
+}

--- a/submarine-codegen/src/test/java/org/kie/submarine/codegen/ConfigGeneratorTest.java
+++ b/submarine-codegen/src/test/java/org/kie/submarine/codegen/ConfigGeneratorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.submarine.codegen;
 
 import com.github.javaparser.ast.expr.NullLiteralExpr;

--- a/submarine-codegen/src/test/java/org/kie/submarine/codegen/GeneratedFileTest.java
+++ b/submarine-codegen/src/test/java/org/kie/submarine/codegen/GeneratedFileTest.java
@@ -2,9 +2,10 @@ package org.kie.submarine.codegen;
 
 import java.nio.charset.StandardCharsets;
 
-import org.assertj.core.api.Assertions;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GeneratedFileTest {
 
@@ -21,16 +22,16 @@ public class GeneratedFileTest {
 
     @Test
     public void relativePath() {
-        Assertions.assertThat(testFile.relativePath()).isEqualTo(TEST_RELATIVE_PATH);
+        assertThat(testFile.relativePath()).isEqualTo(TEST_RELATIVE_PATH);
     }
 
     @Test
     public void contents() {
-        Assertions.assertThat(testFile.contents()).isEqualTo(TEST_CONTENTS);
+        assertThat(testFile.contents()).isEqualTo(TEST_CONTENTS);
     }
 
     @Test
     public void getType() {
-        Assertions.assertThat(testFile.getType()).isEqualTo(TEST_TYPE);
+        assertThat(testFile.getType()).isEqualTo(TEST_TYPE);
     }
 }

--- a/submarine-codegen/src/test/java/org/kie/submarine/codegen/GeneratedFileTest.java
+++ b/submarine-codegen/src/test/java/org/kie/submarine/codegen/GeneratedFileTest.java
@@ -1,0 +1,36 @@
+package org.kie.submarine.codegen;
+
+import java.nio.charset.StandardCharsets;
+
+import org.assertj.core.api.Assertions;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class GeneratedFileTest {
+
+    private static final GeneratedFile.Type TEST_TYPE = GeneratedFile.Type.RULE;
+    private static final String TEST_RELATIVE_PATH = "relativePath";
+    private static final byte[] TEST_CONTENTS = "testContents".getBytes(StandardCharsets.UTF_8);
+
+    private static GeneratedFile testFile;
+
+    @BeforeClass
+    public static void createTestFile() {
+        testFile = new GeneratedFile(TEST_TYPE, TEST_RELATIVE_PATH, TEST_CONTENTS);
+    }
+
+    @Test
+    public void relativePath() {
+        Assertions.assertThat(testFile.relativePath()).isEqualTo(TEST_RELATIVE_PATH);
+    }
+
+    @Test
+    public void contents() {
+        Assertions.assertThat(testFile.contents()).isEqualTo(TEST_CONTENTS);
+    }
+
+    @Test
+    public void getType() {
+        Assertions.assertThat(testFile.getType()).isEqualTo(TEST_TYPE);
+    }
+}

--- a/submarine-codegen/src/test/java/org/kie/submarine/codegen/GeneratedFileTest.java
+++ b/submarine-codegen/src/test/java/org/kie/submarine/codegen/GeneratedFileTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.submarine.codegen;
 
 import java.nio.charset.StandardCharsets;

--- a/submarine-codegen/src/test/java/org/kie/submarine/codegen/GeneratorInterfaceTest.java
+++ b/submarine-codegen/src/test/java/org/kie/submarine/codegen/GeneratorInterfaceTest.java
@@ -1,7 +1,9 @@
 package org.kie.submarine.codegen;
 
 import java.util.Collection;
+import java.util.Map;
 
+import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -17,6 +19,11 @@ public class GeneratorInterfaceTest {
         return new Generator() {
             @Override
             public Collection<MethodDeclaration> factoryMethods() {
+                return null;
+            }
+
+            @Override
+            public Collection<BodyDeclaration<?>> applicationBodyDeclaration() {
                 return null;
             }
 

--- a/submarine-codegen/src/test/java/org/kie/submarine/codegen/GeneratorInterfaceTest.java
+++ b/submarine-codegen/src/test/java/org/kie/submarine/codegen/GeneratorInterfaceTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.submarine.codegen;
 
 import java.util.Collection;

--- a/submarine-codegen/src/test/java/org/kie/submarine/codegen/GeneratorInterfaceTest.java
+++ b/submarine-codegen/src/test/java/org/kie/submarine/codegen/GeneratorInterfaceTest.java
@@ -1,0 +1,44 @@
+package org.kie.submarine.codegen;
+
+import java.util.Collection;
+
+import com.github.javaparser.ast.body.MethodDeclaration;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class GeneratorInterfaceTest {
+
+    @Test
+    public void getLabels() {
+        Assertions.assertThat(getAnonymousGeneratorInstance().getLabels()).isEmpty();
+    }
+
+    private Generator getAnonymousGeneratorInstance() {
+        return new Generator() {
+            @Override
+            public Collection<MethodDeclaration> factoryMethods() {
+                return null;
+            }
+
+            @Override
+            public Collection<GeneratedFile> generate() {
+                return null;
+            }
+
+            @Override
+            public void updateConfig(ConfigGenerator cfg) {
+
+            }
+
+            @Override
+            public void setPackageName(String packageName) {
+
+            }
+
+            @Override
+            public void setDependencyInjection(boolean dependencyInjection) {
+
+            }
+        };
+    }
+}

--- a/submarine-codegen/src/test/java/org/kie/submarine/codegen/metadata/ImageMetaDataTest.java
+++ b/submarine-codegen/src/test/java/org/kie/submarine/codegen/metadata/ImageMetaDataTest.java
@@ -1,0 +1,58 @@
+package org.kie.submarine.codegen.metadata;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ImageMetaDataTest {
+
+    @Test
+    public void getSetLabels() {
+        final ImageMetaData imageMetaData = new ImageMetaData();
+        final List<Map<String, String>> labels = new ArrayList<>();
+
+        final Map<String, String> firstLabels = new HashMap<>();
+        firstLabels.put("firstLabelsKey1", "firstLabelsValue1");
+
+        final Map<String, String> secondLabels = new HashMap<>();
+        secondLabels.put("secondLabelsKey1", "secondLabelsValue1");
+
+        labels.add(firstLabels);
+        labels.add(secondLabels);
+
+        imageMetaData.setLabels(labels);
+        assertThat(imageMetaData.getLabels()).isSameAs(labels);
+        assertThat(imageMetaData.getLabels()).containsExactlyInAnyOrder(firstLabels, secondLabels);
+    }
+
+    @Test
+    public void getSetLabelsNull() {
+        final ImageMetaData imageMetaData = new ImageMetaData();
+        imageMetaData.setLabels(null);
+        assertThat(imageMetaData.getLabels()).isNull();
+    }
+
+    @Test
+    public void add() {
+        final ImageMetaData imageMetaData = new ImageMetaData();
+
+        final Map<String, String> labels = new HashMap<>();
+        labels.put("firstLabelsKey1", "firstLabelsValue1");
+        imageMetaData.add(labels);
+
+        final Map<String, String> secondLabels = new HashMap<>();
+        secondLabels.put("secondLabelsKey1", "secondLabelsValue1");
+        imageMetaData.add(secondLabels);
+
+        assertThat(imageMetaData.getLabels()).isNotNull();
+        assertThat(imageMetaData.getLabels()).hasSize(1);
+        labels.putAll(secondLabels);
+        assertThat(imageMetaData.getLabels().get(0)).hasSize(2);
+        assertThat(imageMetaData.getLabels().get(0)).containsAllEntriesOf(labels);
+    }
+}

--- a/submarine-codegen/src/test/java/org/kie/submarine/codegen/metadata/ImageMetaDataTest.java
+++ b/submarine-codegen/src/test/java/org/kie/submarine/codegen/metadata/ImageMetaDataTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.submarine.codegen.metadata;
 
 import java.util.ArrayList;


### PR DESCRIPTION
- Adds first few unit tests
- Fixes writing image metadata file in ApplicationGenerator - it failed to create the file when any of its path directories was not created 

Please squash if merging. 